### PR TITLE
Use UniProt purl's for UniProt data

### DIFF
--- a/dipper/curie_map.yaml
+++ b/dipper/curie_map.yaml
@@ -157,9 +157,9 @@
 'HPRD' : 'http://www.hprd.org/protein/'
 'NCBIProtein' : 'http://www.ncbi.nlm.nih.gov/protein/'
 'PDB' : 'http://identifiers.org/PDB:'
-'SwissProt' : 'http://identifiers.org/SwissProt:'
-'TrEMBL' : 'http://www.uniprot.org/uniprot/'
-'UniProtKB' : 'http://identifiers.org/uniprot/'
+'SwissProt' : 'http://purl.uniprot.org/uniprot/'
+'TrEMBL' : 'http://purl.uniprot.org/uniprot/'
+'UniProtKB' : 'http://purl.uniprot.org/uniprot/'
 
 #chemicals
 'CID' : 'http://pubchem.ncbi.nlm.nih.gov/compound/'


### PR DESCRIPTION
The UniProt purls resolve to www.uniprot.org if html is requested but if the user wants RDF they get RDF. Using UniProt purls makes cross querying between sparql.uniprot.org and other data sources easier.