### PR TITLE
Revert "Use UniProt purl's for UniProt data"

### DIFF
--- a/dipper/curie_map.yaml
+++ b/dipper/curie_map.yaml
@@ -157,9 +157,9 @@
 'HPRD' : 'http://www.hprd.org/protein/'
 'NCBIProtein' : 'http://www.ncbi.nlm.nih.gov/protein/'
 'PDB' : 'http://identifiers.org/PDB:'
-'SwissProt' : 'http://purl.uniprot.org/uniprot/'
-'TrEMBL' : 'http://purl.uniprot.org/uniprot/'
-'UniProtKB' : 'http://purl.uniprot.org/uniprot/'
+'SwissProt' : 'http://identifiers.org/SwissProt:'
+'TrEMBL' : 'http://www.uniprot.org/uniprot/'
+'UniProtKB' : 'http://identifiers.org/uniprot/'
 
 #chemicals
 'CID' : 'http://pubchem.ncbi.nlm.nih.gov/compound/'


### PR DESCRIPTION
Reverts monarch-initiative/dipper#300

This has some implications downstream, specifically in how SciGraph resolves IRI's to curies.  The issue here is having three curie prefixes with the same IRI prefix mapping.  This breaks the scigraph-services, essentially both keys and values need to be unique sets.

Could we alternatively have a single curie prefix that maps to http://purl.uniprot.org/uniprot/ ?