### PR TITLE
Fixed bug in XSD:boolean URI

### DIFF
--- a/dipper/utils/GraphUtils.py
+++ b/dipper/utils/GraphUtils.py
@@ -229,7 +229,7 @@ class GraphUtils:
         replaced_by = URIRef(self.cu.get_uri(self.properties['replaced_by']))
 
         n1 = URIRef(self.cu.get_uri(oldid))
-        g.add((n1, OWL['deprecated'], Literal(True, datatype=XSD[bool])))
+        g.add((n1, OWL['deprecated'], Literal(True, datatype=XSD['boolean'])))
 
         if newids is not None:
             if len(newids) == 1:
@@ -530,7 +530,7 @@ class GraphUtils:
         """
         self.addTriple(
             graph, node_id, self.annotation_properties['clique_leader'],
-            Literal(True, datatype=XSD[bool]), True)
+            Literal(True, datatype=XSD['boolean']), True)
         return
 
     @staticmethod


### PR DESCRIPTION
Boolean in dipper output currently look like `<http://www.ncbi.nlm.nih.gov/pubmed/11566854> :MONARCH_cliqueLeader "true"^^xsd: .` The python code was calling `XSD[bool]`, which works for some reason and just returns the namespace URI. Changed to `XSD['boolean']` so that the correct URI will be output as `xsd:boolean`.