### PR TITLE
Change OBAN relation, skolemize bnodes by default

### DIFF
--- a/dipper.py
+++ b/dipper.py
@@ -149,7 +149,7 @@ def main():
         else:
             logging.basicConfig(level=logging.INFO)
 
-    if args.use_bnodes is not True:
+    if args.use_bnodes is False:
         logger.info("Will materialize all BNodes into BASE space")
 
     if args.query is not None:

--- a/dipper.py
+++ b/dipper.py
@@ -149,7 +149,7 @@ def main():
         else:
             logging.basicConfig(level=logging.INFO)
 
-    if args.use_bnodes is False:
+    if not args.use_bnodes:
         logger.info("Will materialize all BNodes into BASE space")
 
     if args.query is not None:

--- a/dipper.py
+++ b/dipper.py
@@ -102,8 +102,9 @@ def main():
     # BNodes can't be visualized in Protege,
     # so you can materialize them for testing purposes with this flag
     parser.add_argument(
-        '-nb', '--skolemize_bnodes',
-        help="convert blank nodes into identified nodes", action="store_true")
+        '-b', '--use_bnodes',
+        help="use blank nodes instead of skolemizing", action="store_true",
+        default=False)
 
     # TODO this preconfiguration should probably live in the conf.json,
     #   and the same filter be applied to all sources
@@ -148,7 +149,7 @@ def main():
         else:
             logging.basicConfig(level=logging.INFO)
 
-    if args.skolemize_bnodes is True:
+    if args.use_bnodes is not True:
         logger.info("Will materialize all BNodes into BASE space")
 
     if args.query is not None:
@@ -196,10 +197,11 @@ def main():
         imported_module = importlib.import_module(module)
         source_class = getattr(imported_module, src)
         mysource = None
+        are_bnodes_skolemized = not args.use_bnodes
         if src in taxa_supported:
-            mysource = source_class(args.graph, args.skolemize_bnodes, tax_ids)
+            mysource = source_class(args.graph, are_bnodes_skolemized, tax_ids)
         else:
-            mysource = source_class(args.graph, args.skolemize_bnodes)
+            mysource = source_class(args.graph, are_bnodes_skolemized)
         if args.parse_only is False:
             start_fetch = time.clock()
             mysource.fetch(args.force)

--- a/dipper/graph/RDFGraph.py
+++ b/dipper/graph/RDFGraph.py
@@ -19,7 +19,7 @@ class RDFGraph(ConjunctiveGraph, DipperGraph):
     curie_util = CurieUtil(curie_map.get())
     curie_map = curie_map
 
-    def __init__(self, are_bnodes_skized=False):
+    def __init__(self, are_bnodes_skized=True):
         super().__init__()
         self.are_bnodes_skized = are_bnodes_skized
 

--- a/dipper/graph/StreamedGraph.py
+++ b/dipper/graph/StreamedGraph.py
@@ -19,7 +19,7 @@ class StreamedGraph(DipperGraph):
     curie_util = CurieUtil(curie_map.get())
     curie_map = curie_map
 
-    def __init__(self, are_bnodes_skized=False, file_handle=None, fmt='nt'):
+    def __init__(self, are_bnodes_skized=True, file_handle=None, fmt='nt'):
         self.are_bnodes_skized = are_bnodes_skized
         self.fmt = fmt
         self.file_handle = file_handle

--- a/dipper/models/assoc/Association.py
+++ b/dipper/models/assoc/Association.py
@@ -40,7 +40,7 @@ class Assoc:
         'towards': 'RO:0002503',
         'has_subject': 'OBAN:association_has_subject',
         'has_object': 'OBAN:association_has_object',
-        'has_predicate': 'OBAN:association_has_object_property',
+        'has_predicate': 'OBAN:association_has_predicate',
         'is_about': 'IAO:0000136',
         'has_evidence': 'RO:0002558',
         'has_source': 'dc:source',

--- a/tests/test_ctd.py
+++ b/tests/test_ctd.py
@@ -38,7 +38,7 @@ class CTDTestCase(SourceTestCase):
                        WHERE {
                            ?assoc a OBAN:association ;
                            OBAN:association_has_object ?disease ;
-                           OBAN:association_has_object_property ?rel ;
+                           OBAN:association_has_predicate ?rel ;
                            OBAN:association_has_subject ?chemical .}
                        """
 

--- a/tests/test_gwascatalog.py
+++ b/tests/test_gwascatalog.py
@@ -201,14 +201,14 @@ class TestGwasSNPModel(unittest.TestCase):
                     OBO:RO_0002558 OBO:ECO_0000213 ;
                     dc:source PMID:25918132 ;
                     OBAN:association_has_object EFO:0000270 ;
-                    OBAN:association_has_object_property OBO:RO_0002326 ;
+                    OBAN:association_has_predicate OBO:RO_0002326 ;
                     OBAN:association_has_subject ?snp .
 
                 <https://monarchinitiative.org/MONARCH_70a05d8eb1c3d4b037d7cc04ffa625a7d85b5c46> a OBAN:association ;
                     OBO:RO_0002558 OBO:ECO_0000213 ;
                     dc:source PMID:25918132 ;
                     OBAN:association_has_object EFO:0006995 ;
-                    OBAN:association_has_object_property OBO:RO_0002326 ;
+                    OBAN:association_has_predicate OBO:RO_0002326 ;
                     OBAN:association_has_subject ?snp .
 
                 EFO:0000270 a owl:Class ;

--- a/tests/test_impc.py
+++ b/tests/test_impc.py
@@ -68,7 +68,7 @@ class EvidenceProvenanceTestCase(unittest.TestCase):
         """
         Functional test for _add_evidence()
         """
-        impc = IMPC('rdf_graph', True)
+        impc = IMPC('rdf_graph', False)
         impc_map = impc.open_and_parse_yaml(impc.map_files['impc_map'])
 
         (p_value, percentage_change, effect_size) = self.test_set_1[23:26]
@@ -167,7 +167,7 @@ class EvidenceProvenanceTestCase(unittest.TestCase):
         """
         Functional test for _add_study_provenance()
         """
-        impc = IMPC('rdf_graph', False)
+        impc = IMPC('rdf_graph', True)
         impc_map = impc.open_and_parse_yaml(impc.map_files['impc_map'])
 
         impc._add_assertion_provenance(self.assoc_curie,
@@ -179,7 +179,7 @@ class EvidenceProvenanceTestCase(unittest.TestCase):
                           MONARCH:test_association OBO:SEPIO_0000015 ?assertion.
                           ?assertion a OBO:SEPIO_0000001 ;
                               OBO:SEPIO_0000018 <http://www.mousephenotype.org/> ;
-                              OBO:SEPIO_0000111 _:evidence  .
+                              OBO:SEPIO_0000111 <https://monarchinitiative.org/.well-known/genid/study>  .
 
                           <http://www.mousephenotype.org/> a foaf:organization ;
                               rdfs:label "International Mouse Phenotyping Consortium" .
@@ -244,7 +244,7 @@ class EvidenceProvenanceTestCase(unittest.TestCase):
                       WHERE {
                           ?assoc OBO:SEPIO_0000007 ?evidenceline .
                           ?evidenceline a OBO:ECO_0000015 ;
-                              OBO:SEPIO_0000085 _:study  .
+                              OBO:SEPIO_0000085 <https://monarchinitiative.org/.well-known/genid/study> .
 
                           ?study a OBO:OBI_0000471 ;
                               OBO:SEPIO_0000114 ?param ;

--- a/tests/test_impc.py
+++ b/tests/test_impc.py
@@ -179,7 +179,7 @@ class EvidenceProvenanceTestCase(unittest.TestCase):
                           MONARCH:test_association OBO:SEPIO_0000015 ?assertion.
                           ?assertion a OBO:SEPIO_0000001 ;
                               OBO:SEPIO_0000018 <http://www.mousephenotype.org/> ;
-                              OBO:SEPIO_0000111 <https://monarchinitiative.org/.well-known/genid/study>  .
+                              OBO:SEPIO_0000111 <https://monarchinitiative.org/.well-known/genid/evidence>  .
 
                           <http://www.mousephenotype.org/> a foaf:organization ;
                               rdfs:label "International Mouse Phenotyping Consortium" .

--- a/tests/test_reactome.py
+++ b/tests/test_reactome.py
@@ -32,7 +32,7 @@ class ReactomeTestCase(unittest.TestCase):
                            ?assoc a OBAN:association ;
                                OBO:RO_0002558 OBO:ECO_0000501 ;
                                OBAN:association_has_object REACT:R-BTA-3000480 ;
-                               OBAN:association_has_object_property OBO:RO_0002331 ;
+                               OBAN:association_has_predicate OBO:RO_0002331 ;
                                OBAN:association_has_subject ENSEMBL:ENSBTAP00000013354 .
 
                            REACT:R-BTA-3000480 a owl:Class ;


### PR DESCRIPTION
Change 
http://purl.org/oban/association_has_object_property
to
http://purl.org/oban/association_has_predicate

Skolemize bnodes by default

Closes https://github.com/monarch-initiative/dipper/issues/278, https://github.com/monarch-initiative/dipper/issues/380