### PR TITLE
mgi running and  host change for fly 

### DIFF
--- a/dipper/sources/FlyBase.py
+++ b/dipper/sources/FlyBase.py
@@ -164,7 +164,7 @@ class FlyBase(PostgreSQLSource):
 
         # create the connection details for Flybase
         cxn = {
-            'host': 'flybase.org', 'database': 'flybase', 'port': 5432,
+            'host': 'chado.flybase.org', 'database': 'flybase', 'port': 5432,
             'user': 'flybase', 'password': 'no password'}
 
         self.dataset.setFileAccessUrl(

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -540,18 +540,19 @@ class MGI(PostgreSQLSource):
         model = Model(g)
         line_counter = 0
         raw = '/'.join((self.rawdir, 'all_summary_view'))
-        logger.info("getting alleles with labels and descriptions from all_summary_view")
+        logger.info(
+            "alleles with labels and descriptions from all_summary_view")
         with open(raw, 'r') as f:
             col_count = len(f.readline())  # read the header row; skip
-            # head -1  workspace/build-mgi-ttl/dipper/raw/mgi/all_summary_view|\
+            # head -1 workspace/build-mgi-ttl/dipper/raw/mgi/all_summary_view|\
             # tr '\t' '\n' | grep -n . | \
             # awk -F':' '{col=$1;$1="";print $0,",\t  #" col}'
             for line in f:
                 line_counter += 1
                 # bail if the row is malformed
                 if len(line) != col_count:
-                    logger.warning('Expected ' + col_count + ' columns.')
-                    logger.warning('Recieved ' + len(line) + ' columns.')
+                    logger.warning('Expected ' + str(col_count) + ' columns.')
+                    logger.warning('Recieved ' + str(len(line)) + ' columns.')
                     logger.warning(line.format())
                     continue
                 # no stray tab in the description column

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -540,16 +540,40 @@ class MGI(PostgreSQLSource):
         model = Model(g)
         line_counter = 0
         raw = '/'.join((self.rawdir, 'all_summary_view'))
-        logger.info("getting alleles and their labels and descriptions")
+        logger.info("getting alleles with labels and descriptions from all_summary_view")
         with open(raw, 'r') as f:
-            f.readline()  # read the header row; skip
+            col_count = len(f.readline())  # read the header row; skip
+            # head -1  workspace/build-mgi-ttl/dipper/raw/mgi/all_summary_view|\
+            # tr '\t' '\n' | grep -n . | \
+            # awk -F':' '{col=$1;$1="";print $0,",\t  #" col}'
             for line in f:
                 line_counter += 1
-
-                (accession_key, accid, prefixpart, numericpart, logicaldb_key,
-                 object_key, mgitype_key, private, preferred, createdby_key,
-                 modifiedby_key, creation_date, modification_date, mgiid,
-                 subtype, description, short_description) = line.split('\t')
+                # bail if the row is malformed
+                if len(line) != col_count:
+                    logger.warning('Expected ' + col_count + ' columns.')
+                    logger.warning('Recieved ' + len(line) + ' columns.')
+                    logger.warning(line.format())
+                    continue
+                # no stray tab in the description column
+                (
+                    accession_key,
+                    accid,
+                    prefixpart,
+                    numericpart,
+                    logicaldb_key,
+                    object_key,
+                    mgitype_key,
+                    private,
+                    preferred,
+                    createdby_key,
+                    modifiedby_key,
+                    creation_date,
+                    modification_date,
+                    mgiid,
+                    subtype,
+                    description,
+                    short_description
+                ) = line.split('\t')
                 # NOTE: May want to filter alleles based on the preferred field
                 # (preferred = 1) or will get duplicates
                 # (24288, to be exact...

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -418,6 +418,7 @@ class MGI(PostgreSQLSource):
                                 'strain', re.sub(r':', '', str(strain_id)))
                         strain_id += re.sub(r':', '', str(mgiid))
                         strain_id = re.sub(r'^_', '_:', strain_id)
+                        strain_id = re.sub(r'::', ':', strain_id)
                         model.addDescription(
                             strain_id,
                             "This genomic background is unknown.  " +
@@ -643,12 +644,20 @@ class MGI(PostgreSQLSource):
         line_counter = 0
         logger.info(
             "adding alleles, mapping to markers, " +
-            "extracting their sequence alterations")
+            "extracting their sequence alterations " +
+            "from all_allele_view")
         raw = '/'.join((self.rawdir, 'all_allele_view'))
         with open(raw, 'r') as f:
-            f.readline()  # read the header row; skip
+            col_count = f.readline().count('\t')  # read the header row; skip
             for line in f:
                 line_counter += 1
+                                cols = line.count('\t')
+                # bail if the row is malformed
+                if cols != col_count:
+                    logger.warning('Expected ' + str(col_count) + ' columns.')
+                    logger.warning('Recieved ' + str(cols) + ' columns.')
+                    logger.warning(line.format())
+                    continue
 
                 (allele_key, marker_key, strain_key, mode_key, allele_type_key,
                  allele_status_key, transmission_key, collection_key, symbol,

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -543,16 +543,17 @@ class MGI(PostgreSQLSource):
         logger.info(
             "alleles with labels and descriptions from all_summary_view")
         with open(raw, 'r') as f:
-            col_count = len(f.readline())  # read the header row; skip
+            col_count = f.readline().count('\t')  # read the header row; skip
             # head -1 workspace/build-mgi-ttl/dipper/raw/mgi/all_summary_view|\
             # tr '\t' '\n' | grep -n . | \
             # awk -F':' '{col=$1;$1="";print $0,",\t  #" col}'
             for line in f:
                 line_counter += 1
+                cols = line.count('\t')
                 # bail if the row is malformed
-                if len(line) != col_count:
+                if cols != col_count:
                     logger.warning('Expected ' + str(col_count) + ' columns.')
-                    logger.warning('Recieved ' + str(len(line)) + ' columns.')
+                    logger.warning('Recieved ' + str(cols) + ' columns.')
                     logger.warning(line.format())
                     continue
                 # no stray tab in the description column

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -651,7 +651,7 @@ class MGI(PostgreSQLSource):
             col_count = f.readline().count('\t')  # read the header row; skip
             for line in f:
                 line_counter += 1
-                                cols = line.count('\t')
+                cols = line.count('\t')
                 # bail if the row is malformed
                 if cols != col_count:
                     logger.warning('Expected ' + str(col_count) + ' columns.')


### PR DESCRIPTION
- flybase moved their read only postgresql instance to a machine named `chado`
  - unannounced, found by looking for pages with recent edits in their wiki
- in MGI guard against stray tabs in TSV by skipping rows with the wrong number of columns
  - tabs are not invalid in the database and are not escaped when selected out
- we were producing blank nodes with double colons  `_::yadayamgibackground`

Have a ticket in to mgi to address the specific case we are working around
suggest they trim leading/trailing whitespace of freetext on ingest.


Flybase is not completing because a FBgnID worms (flutters?) into dbxref and we do not supply a curie for it.    
note Flybase is not sending the FBgn in their dbxref dataset we are doing this ourselves. 