### PR TITLE
MGI

### DIFF
--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -289,7 +289,7 @@ class MGI(PostgreSQLSource):
             if 'Force' in query_map:
                 force = query_map['Force']
             self.fetch_query_from_pgdb(
-                query_map['outfile'], query, None, cxn, force)
+                query_map['outfile'], query, None, cxn, force=force)
         # always get this - it has the verion info
         self.fetch_transgene_genes_from_db(cxn)
 

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -56,7 +56,7 @@ class MGI(PostgreSQLSource):
         {
           'query': '../../resources/sql/mgi_dbinfo.sql',
           'outfile': 'mgi_dbinfo',
-          'Force' : True
+          'Force': True
         },
         {
           'query': '../../resources/sql/gxd_genotype_view.sql',
@@ -128,7 +128,7 @@ class MGI(PostgreSQLSource):
         },
         {
           'query': '../../resources/sql/mrk_location_cache.sql',
-          'outfile': 'mrk_location_cache' # gene locations
+          'outfile': 'mrk_location_cache'  # gene locations
         }
     ]
 
@@ -279,15 +279,15 @@ class MGI(PostgreSQLSource):
 
         # process the tables
         # self.fetch_from_pgdb(self.tables, cxn, 100)  # for testing only
-        #self.fetch_from_pgdb(self.tables, cxn, None, is_dl_forced)
+        # self.fetch_from_pgdb(self.tables, cxn, None, is_dl_forced)
 
         for query_map in self.resources:
             query_fh = open(os.path.join(
                 os.path.dirname(__file__), query_map['query']), 'r')
             query = query_fh.read()
             force = False
-            if 'Force' in query_map;
-               force = query_map['Force']
+            if 'Force' in query_map:
+                force = query_map['Force']
             self.fetch_query_from_pgdb(
                 query_map['outfile'], query, None, cxn, force)
         # always get this - it has the verion info

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -1257,7 +1257,7 @@ class MGI(PostgreSQLSource):
         raw = '/'.join((self.rawdir, 'bib_acc_view'))
         with open(raw, 'r', encoding="utf8") as csvfile:
             filereader = csv.reader(csvfile, delimiter='\t', quotechar='\"')
-            header = filereader.getline()
+            header = filereader.readline()
             if len(header) != 6:
                 logger.error('bib_acc_view expected 6 columns got: %s', header)
             for line in filereader:
@@ -1286,7 +1286,7 @@ class MGI(PostgreSQLSource):
         line_counter = 1
         with open(raw, 'r', encoding="utf8") as csvfile:
             filereader = csv.reader(csvfile, delimiter='\t', quotechar='\"')
-            header = filereader.getline()
+            header = filereader.readline()
 
             for line in filereader:
                 line_counter += 1

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -56,6 +56,7 @@ class MGI(PostgreSQLSource):
         {
           'query': '../../resources/sql/mgi_dbinfo.sql',
           'outfile': 'mgi_dbinfo'
+          'Force' : True
         },
         {
           'query': '../../resources/sql/gxd_genotype_view.sql',
@@ -284,7 +285,11 @@ class MGI(PostgreSQLSource):
             query_fh = open(os.path.join(
                 os.path.dirname(__file__), query_map['query']), 'r')
             query = query_fh.read()
-            self.fetch_query_from_pgdb(query_map['outfile'], query, None, cxn)
+            force = False
+            if 'Force' in query_map;
+               force = query_map['Force']
+            self.fetch_query_from_pgdb(
+                query_map['outfile'], query, None, cxn, force)
         # always get this - it has the verion info
         self.fetch_transgene_genes_from_db(cxn)
 

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -55,7 +55,7 @@ class MGI(PostgreSQLSource):
     resources = [
         {
           'query': '../../resources/sql/mgi_dbinfo.sql',
-          'outfile': 'mgi_dbinfo'
+          'outfile': 'mgi_dbinfo',
           'Force' : True
         },
         {

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -1257,7 +1257,7 @@ class MGI(PostgreSQLSource):
         raw = '/'.join((self.rawdir, 'bib_acc_view'))
         with open(raw, 'r', encoding="utf8") as csvfile:
             filereader = csv.reader(csvfile, delimiter='\t', quotechar='\"')
-            header = filereader.readline()
+            header = next(filereader)
             if len(header) != 6:
                 logger.error('bib_acc_view expected 6 columns got: %s', header)
             for line in filereader:
@@ -1286,7 +1286,7 @@ class MGI(PostgreSQLSource):
         line_counter = 1
         with open(raw, 'r', encoding="utf8") as csvfile:
             filereader = csv.reader(csvfile, delimiter='\t', quotechar='\"')
-            header = filereader.readline()
+            header = next(filereader)
 
             for line in filereader:
                 line_counter += 1
@@ -1316,8 +1316,8 @@ class MGI(PostgreSQLSource):
                     # some DOIs have un-urlencoded brackets <>
                     accid = re.sub(r'<', '%3C', accid)
                     accid = re.sub(r'>', '%3E', accid)
-                    pub_id = 'DOI:'+ accid
-                    
+                    pub_id = 'DOI:' + accid
+
                 elif logicaldb_key == '1' and re.match(r'J:', prefixpart):
                     # we can skip the J numbers
                     continue

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -1252,15 +1252,16 @@ class MGI(PostgreSQLSource):
             g = self.graph
         model = Model(g)
         # firstpass, get the J number mapping, and add to the global hash
-        line_counter = 0
+        line_counter = 1
         logger.info('populating pub id hash')
         raw = '/'.join((self.rawdir, 'bib_acc_view'))
         with open(raw, 'r', encoding="utf8") as csvfile:
             filereader = csv.reader(csvfile, delimiter='\t', quotechar='\"')
+            header = filereader.getline()
+            if len(header) != 6:
+                logger.error('bib_acc_view expected 6 columns got: %s', header)
             for line in filereader:
                 line_counter += 1
-                if line_counter == 1:
-                    continue  # skip header
                 (accid, prefixpart, numericpart, object_key,
                  logical_db, logicaldb_key) = line
 
@@ -1282,13 +1283,13 @@ class MGI(PostgreSQLSource):
 
         # 2nd pass, look up the MGI identifier in the hash
         logger.info("getting pub equivalent ids")
-        line_counter = 0
+        line_counter = 1
         with open(raw, 'r', encoding="utf8") as csvfile:
             filereader = csv.reader(csvfile, delimiter='\t', quotechar='\"')
+            header = filereader.getline()
+
             for line in filereader:
                 line_counter += 1
-                if line_counter == 1:
-                    continue  # skip header
                 (accid, prefixpart, numericpart, object_key,
                  logical_db, logicaldb_key) = line
 
@@ -1311,7 +1312,12 @@ class MGI(PostgreSQLSource):
                     # some DOIs seem to have spaces
                     # FIXME MGI needs to FIX THESE UPSTREAM!!!!
                     # we'll scrub them here for the time being
-                    pub_id = 'DOI:'+re.sub(r'\s+', '', accid)
+                    accid = re.sub(r'\s+', '', accid)
+                    # some DOIs have un-urlencoded brackets <>
+                    accid = re.sub(r'<', '%3C', accid)
+                    accid = re.sub(r'>', '%3E', accid)
+                    pub_id = 'DOI:'+ accid
+                    
                 elif logicaldb_key == '1' and re.match(r'J:', prefixpart):
                     # we can skip the J numbers
                     continue

--- a/dipper/sources/PostgreSQLSource.py
+++ b/dipper/sources/PostgreSQLSource.py
@@ -34,16 +34,16 @@ class PostgreSQLSource(Source):
                                    port=cxn['port'], user=cxn['user'],
                                    password=cxn['password'])
             cur = con.cursor()
-            for t in tables:
-                logger.info("Fetching data from table %s", t)
-                self._getcols(cur, t)
-                query = ' '.join(("SELECT * FROM", t))
-                countquery = ' '.join(("SELECT COUNT(*) FROM", t))
+            for tab in tables:
+                logger.info("Fetching data from table %s", tab)
+                self._getcols(cur, tab)
+                query = ' '.join(("SELECT * FROM", tab))
+                countquery = ' '.join(("SELECT COUNT(*) FROM", tab))
                 if limit is not None:
                     query = ' '.join((query, "LIMIT", str(limit)))
                     countquery = ' '.join((countquery, "LIMIT", str(limit)))
 
-                outfile = '/'.join((self.rawdir, t))
+                outfile = '/'.join((self.rawdir, tab))
 
                 filerowcount = -1
                 tablerowcount = -1
@@ -54,7 +54,9 @@ class PostgreSQLSource(Source):
                     if os.path.exists(outfile):
                         # get rows in the file
                         filerowcount = self.file_len(outfile)
-                        logger.info("rows in local file: %s", filerowcount)
+                        logger.info(
+                            "(%s) rows in local file vor table %s",
+                            filerowcount, tab)
 
                     # get rows in the table
                     # tablerowcount=cur.rowcount
@@ -64,10 +66,10 @@ class PostgreSQLSource(Source):
                 # rowcount-1 because there's a header
                 if force or filerowcount < 0 or (filerowcount-1) != tablerowcount:
                     if force:
-                        logger.info("Forcing download of %s", t)
+                        logger.info("Forcing download of %s", tab)
                     else:
                         logger.info("%s local (%d) different from remote (%d); fetching.",
-                                    t, filerowcount, tablerowcount)
+                                    tab, filerowcount, tablerowcount)
                     # download the file
                     logger.info("COMMAND:%s", query)
                     outputquery = "COPY ({0}) TO STDOUT WITH DELIMITER AS '\t' CSV HEADER".format(query)

--- a/dipper/sources/PostgreSQLSource.py
+++ b/dipper/sources/PostgreSQLSource.py
@@ -55,7 +55,7 @@ class PostgreSQLSource(Source):
                         # get rows in the file
                         filerowcount = self.file_len(outfile)
                         logger.info(
-                            "(%s) rows in local file vor table %s",
+                            "(%s) rows in local file for table %s",
                             filerowcount, tab)
 
                     # get rows in the table
@@ -113,9 +113,11 @@ class PostgreSQLSource(Source):
         # check local copy.
         # assume that if the # rows are the same, that the table is the same
         # TEC - opinion:
-        # the only thing to assume is that if the counts are different
-        # is the data could not be the same.
-        # to check if they are the same compare digests.
+        #    the only thing to assume is that if the counts are different
+        #    is the data could not be the same.
+        #
+        #    i.e: for MGI, the dbinfo table has a single row that changes
+        #    to check if they are the same sort & compare digests. (
         filerowcount = -1
         tablerowcount = -1
         if not force:

--- a/dipper/sources/PostgreSQLSource.py
+++ b/dipper/sources/PostgreSQLSource.py
@@ -110,6 +110,10 @@ class PostgreSQLSource(Source):
 
         # check local copy.  assume that if the # rows are the same,
         # that the table is the same
+        # TEC - opinion:
+        # the only thing to assume is that if the counts are different
+        # is the data could not be the same.
+        # to check if they are the same compare digests.
         filerowcount = -1
         tablerowcount = -1
         if not force:
@@ -138,11 +142,15 @@ class PostgreSQLSource(Source):
             # Regenerate row count to check integrity
             filerowcount = self.file_len(outfile)
             if (filerowcount-1) < tablerowcount:
-                raise Exception("Download from MGI failed, %s != %s",
-                                (filerowcount-1), tablerowcount)
+                raise Exception(
+                    "Download from %s failed, %s != %s",
+                    cxn['host'] + ':'+cxn['database'],
+                    (filerowcount-1), tablerowcount)
             elif (filerowcount-1) > tablerowcount:
-                logger.warn("Download from MGI larger than count, %s != %s",
-                            (filerowcount-1), tablerowcount)
+                logger.warn(
+                    "Download from %s larger than count, %s != %s",
+                    cxn['host'] + ':'+cxn['database'],
+                    (filerowcount-1), tablerowcount)
         else:
             logger.info("local data same as remote; reusing.")
 

--- a/dipper/sources/PostgreSQLSource.py
+++ b/dipper/sources/PostgreSQLSource.py
@@ -108,8 +108,8 @@ class PostgreSQLSource(Source):
         if limit is not None:
             countquery = ' '.join((countquery, "LIMIT", str(limit)))
 
-        # check local copy.  assume that if the # rows are the same,
-        # that the table is the same
+        # check local copy.
+        # assume that if the # rows are the same, that the table is the same
         # TEC - opinion:
         # the only thing to assume is that if the counts are different
         # is the data could not be the same.
@@ -132,8 +132,9 @@ class PostgreSQLSource(Source):
             if force:
                 logger.info("Forcing download of %s", qname)
             else:
-                logger.info("%s local (%s) different from remote (%s); fetching.",
-                            qname, filerowcount, tablerowcount)
+                logger.info(
+                    "%s local (%s) different from remote (%s); fetching.",
+                    qname, filerowcount, tablerowcount)
             # download the file
             logger.debug("COMMAND:%s", query)
             outputquery = "COPY ({0}) TO STDOUT WITH DELIMITER AS '\t' CSV HEADER".format(query)
@@ -148,7 +149,8 @@ class PostgreSQLSource(Source):
                     (filerowcount-1), tablerowcount)
             elif (filerowcount-1) > tablerowcount:
                 logger.warn(
-                    "Download from %s larger than count, %s != %s",
+                    "Download from %s more rows in file (%s) " + \
+                    "than reported in count(%s)",
                     cxn['host'] + ':'+cxn['database'],
                     (filerowcount-1), tablerowcount)
         else:


### PR DESCRIPTION
DOIs with  unescaped angle brackets. 
they go into rdflib but they don't back come out.

 - comments and logging. 
 - move header process out of loop
 - insist mgi-dbinfo is fetched