### PR TITLE
use curie map to whitelist panther prefixes

### DIFF
--- a/dipper/sources/Panther.py
+++ b/dipper/sources/Panther.py
@@ -179,7 +179,9 @@ class Panther(Source):
                     line = line.decode().strip()
 
                     # parse each row. ancestor_taxon is unused
-                    # HUMAN|Ensembl=ENSG00000184730|UniProtKB=Q0VD83	MOUSE|MGI=MGI=2176230|UniProtKB=Q8VBT6	LDO	Euarchontoglires	PTHR15964
+                    # HUMAN|Ensembl=ENSG00000184730|UniProtKB=Q0VD83
+                    #   	MOUSE|MGI=MGI=2176230|UniProtKB=Q8VBT6
+                    #       	LDO	Euarchontoglires	PTHR15964
                     (a, b, orthology_class, ancestor_taxon,
                      panther_id) = line.split('\t')
                     (species_a, gene_a, protein_a) = a.split('|')
@@ -208,11 +210,13 @@ class Panther(Source):
                     # gene1 AND gene2 are in the taxid list (most-filter)
                     # using OR will get you any associations where
                     # gene1 OR gene2 are in the taxid list (some-filter)
-                    if (self.tax_ids is not None and
-                            (int(re.sub(r'NCBITaxon:', '', taxon_a.rstrip())) not in
-                             self.tax_ids) and
-                            (int(re.sub(r'NCBITaxon:', '', taxon_b.rstrip())) not in
-                             self.tax_ids)):
+                    if (
+                        self.tax_ids is not None and
+                        (int(re.sub(r'NCBITaxon:', '', taxon_a.rstrip()))
+                            not in self.tax_ids) and
+                        (int(re.sub(
+                            r'NCBITaxon:', '', taxon_b.rstrip())) not in
+                            self.tax_ids)):
                         continue
                     else:
                         matchcounter += 1
@@ -391,7 +395,8 @@ class Panther(Source):
         # rewrite Gene:<Xenbase ids> --> Xenbase:<id>
         geneid = re.sub(r'Gene:Xenbase:', 'Xenbase:', geneid)
 
-        if re.match(r'(Gene|ENSEMBLGenome):', geneid):
+        if re.match(r'(Gene|ENSEMBLGenome):', geneid) or
+                re.match(r'Gene_ORFName':, geneid):
             # logger.warning(
             #   "Found an identifier I don't know how to fix (species %s): %s",
             #   sp, geneid)
@@ -403,6 +408,7 @@ class Panther(Source):
         import unittest
         from tests.test_panther import PantherTestCase
 
-        test_suite = unittest.TestLoader().loadTestsFromTestCase(PantherTestCase)
+        test_suite = unittest.TestLoader().loadTestsFromTestCase(
+            PantherTestCase)
 
         return test_suite

--- a/dipper/sources/Panther.py
+++ b/dipper/sources/Panther.py
@@ -395,8 +395,11 @@ class Panther(Source):
         # rewrite Gene:<Xenbase ids> --> Xenbase:<id>
         geneid = re.sub(r'Gene:Xenbase:', 'Xenbase:', geneid)
 
+        # TODO this would be much better done as
+        # if foo not in curie_map:
         if re.match(r'(Gene|ENSEMBLGenome):', geneid) or \
-                re.match(r'Gene_ORFName', geneid):
+                re.match(r'Gene_ORFName', geneid) or \
+                re.match(r'Gene_Name', geneid):
             # logger.warning(
             #   "Found an identifier I don't know how to fix (species %s): %s",
             #   sp, geneid)

--- a/dipper/sources/Panther.py
+++ b/dipper/sources/Panther.py
@@ -406,7 +406,7 @@ class Panther(Source):
         #    #   sp, geneid)
 
         (pfx, lclid) = re.split(r':', geneid)
-        if pfx is None or curie_map.prefix_exists(pfx) is None:
+        if pfx is None or curie_map.get()[pfx] is None:
             logger.warning("No curie prefix (species %s): %s", sp, geneid)
             geneid = None
         return geneid

--- a/dipper/sources/Panther.py
+++ b/dipper/sources/Panther.py
@@ -395,8 +395,8 @@ class Panther(Source):
         # rewrite Gene:<Xenbase ids> --> Xenbase:<id>
         geneid = re.sub(r'Gene:Xenbase:', 'Xenbase:', geneid)
 
-        if re.match(r'(Gene|ENSEMBLGenome):', geneid) or
-                re.match(r'Gene_ORFName':, geneid):
+        if re.match(r'(Gene|ENSEMBLGenome):', geneid) or \
+                re.match(r'Gene_ORFName', geneid):
             # logger.warning(
             #   "Found an identifier I don't know how to fix (species %s): %s",
             #   sp, geneid)

--- a/dipper/sources/Panther.py
+++ b/dipper/sources/Panther.py
@@ -7,6 +7,7 @@ from dipper.models.assoc.OrthologyAssoc import OrthologyAssoc
 from dipper.models.Model import Model
 from dipper.models.Dataset import Dataset
 from dipper import config
+from dipper import curie_map
 
 __author__ = 'nicole'
 
@@ -397,14 +398,17 @@ class Panther(Source):
 
         # TODO this would be much better done as
         # if foo not in curie_map:
-        if re.match(r'(Gene|ENSEMBLGenome):', geneid) or \
-                re.match(r'Gene_ORFName', geneid) or \
-                re.match(r'Gene_Name', geneid):
-            # logger.warning(
-            #   "Found an identifier I don't know how to fix (species %s): %s",
-            #   sp, geneid)
-            geneid = None
+        # if re.match(r'(Gene|ENSEMBLGenome):', geneid) or \
+        #        re.match(r'Gene_ORFName', geneid) or \
+        #        re.match(r'Gene_Name', geneid):
+        #    # logger.warning(
+        #    #"Found an identifier I don't know how to fix (species %s): %s",
+        #    #   sp, geneid)
 
+        (pfx, lclid) = re.split(r':', geneid)
+        if pfx is None or curie_map.prefix_exists(pfx) is None:
+            logger.warning("No curie prefix (species %s): %s", sp, geneid)
+            geneid = None
         return geneid
 
     def getTestSuite(self):

--- a/dipper/sources/Panther.py
+++ b/dipper/sources/Panther.py
@@ -406,8 +406,8 @@ class Panther(Source):
         #    #   sp, geneid)
 
         (pfx, lclid) = re.split(r':', geneid)
-        if pfx is None or curie_map.get()[pfx] is None:
-            logger.warning("No curie prefix (species %s): %s", sp, geneid)
+        if pfx is None or pfx not in curie_map.get():
+            logger.warning("No curie prefix for (species %s): %s", sp, geneid)
             geneid = None
         return geneid
 

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -224,11 +224,12 @@ class Source:
 
         # check if local file exists
         # if no local file, then remote is newer
-        if not os.path.exists(local):
+        if os.path.exists(local):
+            logger.info("File does exist locally")
+        else:
             logger.info("File does not exist locally")
             return True
-        else:
-            logger.info("File does exist locally")
+
         # get remote file details
         if headers is not None:
             req = urllib.request.Request(remote, headers=headers)

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -231,12 +231,13 @@ class Source:
             return True
 
         # get remote file details
-        if headers is not None:
+        if headers is not None and headers != []:
             req = urllib.request.Request(remote, headers=headers)
         else:
             req = urllib.request.Request(remote)
 
         logger.info("Request header: %s", str(req.header_items()))
+
         response = urllib.request.urlopen(req)
 
         try:

--- a/dipper/utils/CurieUtil.py
+++ b/dipper/utils/CurieUtil.py
@@ -54,3 +54,6 @@ class CurieUtil(object):
                              curie[(curie.index(':') + 1):])
         logger.error("Curie prefix not defined for %s", curie)
         return None
+
+    def prefix_exists(self, pfx):
+        return pfx in self.curie_map

--- a/dipper/utils/CurieUtil.py
+++ b/dipper/utils/CurieUtil.py
@@ -19,7 +19,7 @@ class CurieUtil(object):
         '''
         self.curie_map = curie_map
         self.uri_map = {}
-        if curie_map is not None:
+        if curie_map is not None:  # inverse the map
             for key, value in curie_map.items():
                 self.uri_map[value] = key
         return


### PR DESCRIPTION
because blacklisting requires ongoing maintenance with a very long test cycle