### PR TITLE
restore WB xref; output RDF formats; var keyword abatment; remote file change detection 

### DIFF
--- a/dipper-etl.py
+++ b/dipper-etl.py
@@ -125,8 +125,8 @@ def main():
         action="store_true")
 
     parser.add_argument(
-        '--format',
-        help='serialization format: turtle (default), xml, n3, nt, raw',
+        '--dest_fmt',
+        help='serialization format: turtle (default), xml, n3, nt, nq, raw',
         type=str)
 
     parser.add_argument(
@@ -139,11 +139,11 @@ def main():
     if args.taxon is not None:
         tax_ids = [int(t) for t in args.taxon.split(',')]
 
-    taxa_supported = [
+    taxa_supported = [  # these are not taxa
         'Panther', 'NCBIGene', 'BioGrid', 'UCSCBands', 'GeneOntology',
         'Bgee', 'Ensembl', 'StringDB']
 
-    formats_supported = ['xml', 'n3', 'turtle', 'nt', 'ttl', 'raw']
+    formats_supported = ['xml', 'n3', 'turtle', 'nt', 'nq', 'ttl', 'raw']
 
     if args.quiet:
         logging.basicConfig(level=logging.ERROR)
@@ -178,10 +178,10 @@ def main():
         unittest.TextTestRunner(verbosity=2).run(test_suite)
 
     # set serializer
-    if args.format is not None:
-        if args.format in formats_supported:
-            if args.format == 'ttl':
-                args.format = 'turtle'
+    if args.dest_fmt is not None:
+        if args.dest_fmt in formats_supported:
+            if args.dest_fmt == 'ttl':
+                args.dest_fmt = 'turtle'
         else:
             logger.error(
                 "You have specified an invalid serializer: %s", args.format)
@@ -250,7 +250,7 @@ def main():
                             end_axiom_exp-start_axiom_exp)
 
                 start_write = time.clock()
-                mysource.write(format=args.format)
+                mysource.write(fmt=args.dest_fmt)
                 end_write = time.clock()
                 logger.info("Writing time: %d sec", end_write-start_write)
         # if args.no_verify is not True:

--- a/dipper-etl.py
+++ b/dipper-etl.py
@@ -126,7 +126,7 @@ def main():
 
     parser.add_argument(
         '--dest_fmt',
-        help='serialization format: turtle (default), xml, n3, nt, nq, raw',
+        help='serialization format: [turtle], nt, nquads, rdfxml, n3, raw',
         type=str)
 
     parser.add_argument(
@@ -143,7 +143,12 @@ def main():
         'Panther', 'NCBIGene', 'BioGrid', 'UCSCBands', 'GeneOntology',
         'Bgee', 'Ensembl', 'StringDB']
 
-    formats_supported = ['xml', 'n3', 'turtle', 'nt', 'nq', 'ttl', 'raw']
+    formats_supported = [
+        'turtle', 'ttl',
+        'ntriples', 'nt',
+        'nquads', 'nq',
+        'rdfxml',  'xml',
+        'notation3', 'n3',  'raw']
 
     if args.quiet:
         logging.basicConfig(level=logging.ERROR)
@@ -182,13 +187,21 @@ def main():
         if args.dest_fmt in formats_supported:
             if args.dest_fmt == 'ttl':
                 args.dest_fmt = 'turtle'
+            elif args.dest_fmt == 'ntriples':
+                args.dest_fmt = 'nt'
+            elif args.dest_fmt == 'nq':
+                args.dest_fmt = 'nquads'
+            elif args.dest_fmt == 'xml':
+                args.dest_fmt = 'rdfxml'
+            elif args.dest_fmt == 'notation3':
+                args.dest_fmt = 'n3'
         else:
             logger.error(
-                "You have specified an invalid serializer: %s", args.format)
+                "You have specified an invalid serializer: %s", args.dest_fmt)
 
             exit(0)
     else:
-        args.format = 'turtle'
+        args.dest_fmt = 'turtle'
 
     # iterate through all the sources
     for source in args.sources.split(','):

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -116,7 +116,8 @@ class Source:
         """
         This convenience method will write out all of the graphs
         associated with the source.
-        Right now these are hardcoded to be a single "graph" and a "dataset".
+        Right now these are hardcoded to be a single "graph"
+        and a "src_dataset.ttl" and a "src_test.ttl"
         If you do not supply stream='stdout'
         it will default write these to files.
 

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -271,7 +271,7 @@ class Source:
                         "New Remote file existsbut it is SMALLER")
                     return True
                 else:
-                    logger.info(
+                    logger.info(  # filesize is a fairly imperfect metric here
                         "New Remote file has same filesize--will not download")
         elif st[ST_SIZE] != size:
             logger.info(

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -239,7 +239,7 @@ class Source:
 
         try:
             resp_headers = response.info()
-            size = resp_headers.get('Content-Length')
+            size = int(resp_headers.get('Content-Length'))
             last_modified = resp_headers.get('Last-Modified')
         except OSError as e:  # URLError?
             resp_headers = None

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -242,8 +242,8 @@ class Source:
 
         try:
             resp_headers = response.info()
-            size = resp_headers.get('Content-length')
-            last_modified = resp_headers.get('last-modified')  # check me
+            size = resp_headers.get('Content-Length')
+            last_modified = resp_headers.get('Last-Modified')
         except OSError as e:  # URLError?
             resp_headers = None
             size = 0
@@ -264,12 +264,16 @@ class Source:
             # check date on local vs remote file
             if dt_obj > datetime.utcfromtimestamp(st[ST_CTIME]):
                 # check if file size is different
-                if st[ST_SIZE] != size:
-                    logger.info("Newer file exists on remote server")
+                if st[ST_SIZE] < size:
+                    logger.info("New Remote file exists")
+                    return True
+                if st[ST_SIZE] > size:
+                    logger.warning(
+                        "New Remote file existsbut it is SMALLER")
                     return True
                 else:
                     logger.info(
-                        "Remote file has same filesize--will not download")
+                        "New Remote file has same filesize--will not download")
         elif st[ST_SIZE] != size:
             logger.info(
                 "Object on server is difference size to local file")

--- a/dipper/sources/WormBase.py
+++ b/dipper/sources/WormBase.py
@@ -86,13 +86,14 @@ class WormBase(Source):
         #   'file': 'c_elegans.PRJNA13758.orthologs.txt.gz',
         #   'url': wbdev + species +
         #   '/annotation/c_elegans.PRJNA13758.WS249.orthologs.txt.gz'},
-        # 'xrefs': { # no longer exists 2017-11-10
-        #    'file': 'c_elegans.PRJNA13758.xrefs.txt.gz',
-        #    'url': wbprod + species +
-        #    '/c_elegans.PRJNA13758.WSNUMBER.xrefs.txt.gz'},
+          'xrefs': { # moved under 'annotation' 2017-11-10
+            'file': 'c_elegans.PRJNA13758.xrefs.txt.gz',
+            'url': wbprod + species +
+            '/annotation/c_elegans.PRJNA13758.WSNUMBER.xrefs.txt.gz'},
         # 'letter': { # no longer exists 2016-11-18
         #    'file': 'letter.WSNUMBER',
         #    'url': wbprod + '/letter.WSNUMBER'},
+
         'checksums': {
             'file': 'CHECKSUMS',
             'url':  wbprod + '/CHECKSUMS'}

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -43,7 +43,9 @@ class SourceTestCase(unittest.TestCase):
             try:
                 properties = GraphUtils.get_properties_from_graph(self.source.graph)
                 GraphUtils.add_property_axioms(self.source.graph, properties)
-                self.source.write(format='turtle')
+                self.source.write()  # default to  fmt='turtle'
+                #self.source.write(fmt='nt')
+                #self.source.write(fmt='nquads')
             except Exception as WriteException:
                 logger.error(WriteException)
                 self.assertFalse(True, "Write failed")


### PR DESCRIPTION
 - wormbase played hide the xref file
 - extend the RDF formats  data files may be output as
    - now includes nquads
 - ensure `_dataaet` and `_test` files are only written as turtle 
 - reduce the usage of python keywords as user variables i.e `format`
 - make http headers have RCF specified case (I believe lib took care of it anyway)
 - corrected string representation of number that likely tainted file size comparisons  
 