### PR TITLE
Fixes for flybase, hpoa, mmrrc

### DIFF
--- a/dipper/sources/FlyBase.py
+++ b/dipper/sources/FlyBase.py
@@ -57,8 +57,7 @@ class FlyBase(PostgreSQLSource):
         'dbxref',               # done
         'phenotype_cvterm',     # done
         'phendesc',             # done
-        'environment_cvterm',   # done
-        'stockprop'
+        'environment_cvterm'   # done
         # 'feature_cvterm'
         # TODO to get better feature types than (what) is in the feature table
         # itself  (watch out for is_not)
@@ -68,6 +67,10 @@ class FlyBase(PostgreSQLSource):
         {
             'query': '../../resources/sql/fb/feature_relationship.sql',
             'outfile': 'feature_relationship'
+        },
+        {
+            'query': '../../resources/sql/fb/stockprop.sql',
+            'outfile': 'stockprop'
         }
     ]
 
@@ -2101,7 +2104,7 @@ class FlyBase(PostgreSQLSource):
                 # skip comments
                 if re.match(r'#', ''.join(line)) or ''.join(line) == '':
                     continue
-                (stockprop_id, stock_id, type_id, value, rank) = line
+                (stockprop_id, stock_id, cvterm, value, rank) = line
 
                 line_counter += 1
 
@@ -2112,7 +2115,7 @@ class FlyBase(PostgreSQLSource):
 
                 sid = self.idhash['stock'].get(stock_id)
                 # linked_image
-                if int(type_id) == 136340 and re.match(r'FBim', value):
+                if cvterm == "linked_image" and re.match(r'FBim', value):
                     # FIXME make sure this image url is perm
                     image_url = \
                         'http://flybase.org/tmp-shared/reports/'+value+'.png'

--- a/dipper/sources/HPOAnnotations.py
+++ b/dipper/sources/HPOAnnotations.py
@@ -231,8 +231,11 @@ class HPOAnnotations(Source):
             for row in filereader:
                 line_counter += 1
                 row = [str(col).strip() for col in row]
+                # Note from Seb in Dec 2017, a 15th column was added
+                # inadverterntly and will be removed in the winter 2018
+                # release of hpo data
                 (db, num, name, qual, pheno_id, publist, eco, onset, freq, w,
-                 asp, syn, date, curator) = row
+                 asp, syn, date, curator, extra) = row
                 disease_id = db + ":" + num
 
                 if self.testMode:

--- a/dipper/sources/MMRRC.py
+++ b/dipper/sources/MMRRC.py
@@ -272,7 +272,7 @@ class MMRRC(Source):
                 # make variant loci for each gene
                 if len(variants) > 0:
                     for v in variants:
-                        vl_id = v
+                        vl_id = v.strip()
                         vl_symbol = self.id_label_hash[vl_id]
                         geno.addAllele(vl_id, vl_symbol,
                                        geno.genoparts['variant_locus'])

--- a/resources/sql/fb/stockprop.sql
+++ b/resources/sql/fb/stockprop.sql
@@ -2,4 +2,3 @@ SELECT stockprop_id, stock_id, name, value, rank
 FROM stockprop
 INNER JOIN cvterm
 ON stockprop.type_id = cvterm.cvterm_id
-LIMIT 10

--- a/resources/sql/fb/stockprop.sql
+++ b/resources/sql/fb/stockprop.sql
@@ -1,0 +1,5 @@
+SELECT stockprop_id, stock_id, name, value, rank
+FROM stockprop
+INNER JOIN cvterm
+ON stockprop.type_id = cvterm.cvterm_id
+LIMIT 10

--- a/scripts/treeify-hpo.py
+++ b/scripts/treeify-hpo.py
@@ -1,0 +1,78 @@
+from dipper.graph.RDFGraph import RDFGraph
+from rdflib.namespace import RDFS
+from dipper.utils.CurieUtil import CurieUtil
+from dipper import curie_map
+from rdflib import URIRef
+import copy
+import json
+from collections import OrderedDict
+
+def main():
+
+    hpo = RDFGraph()
+    root = "HP:0000118"
+    hpo_terms = OrderedDict()
+
+    hpo.parse("http://purl.obolibrary.org/obo/hp.owl", format='xml')
+    hpo.bind_all_namespaces()
+    hpo.bind("oboInOwl", "http://www.geneontology.org/formats/oboInOwl#")
+
+    tree = {}
+    tree[root] = {}
+    path = []
+
+    hpo_to_tree(root, hpo_terms, hpo, tree, path)
+
+    with open('hpo-tree.json', 'w') as outfile:
+        json.dump(tree, outfile)
+
+    with open('hpo-terms.tsv', 'w') as outfile:
+        for key, value in hpo_terms.items():
+            outfile.write("{0}\t{1}\t{2}\t{3}\n".format(
+                key, value['label'], "|".join(value['lay_person']), value['parents']
+            ))
+
+def hpo_to_tree(cls, hpo_terms, hpo_graph, tree, path):
+    tree_path = copy.copy(path)
+    tree_path.append(cls)
+    curie_util = CurieUtil(curie_map.get())
+    if cls not in hpo_terms:
+        hpo_terms[cls] = {
+            'label': hpo_graph.label(URIRef(curie_util.get_uri(cls)))
+        }
+        parents = hpo_graph.objects(URIRef(curie_util.get_uri(cls)), RDFS.subClassOf)
+        hpo_terms[cls]['parents'] = len(list(parents))
+
+        lay_person = get_lay_person(cls, hpo_graph)
+        hpo_terms[cls]["lay_person"] = lay_person
+
+    # Traverse the tree to get to the input class
+    position = tree[tree_path[0]]
+    for term in tree_path[1:]:
+        position = position[term]
+
+    for sub_class in hpo_graph.subjects(RDFS.subClassOf, URIRef(curie_util.get_uri(tree_path[-1]))):
+        curie = curie_util.get_curie(sub_class).replace("OBO:HP_", "HP:")
+        position[curie] = {}
+        hpo_to_tree(curie, hpo_terms, hpo_graph, tree, tree_path)
+
+
+def get_lay_person(cls, hpo_graph):
+    lay_synonyms = []
+    lay_person_query = """
+        SELECT ?lp
+        WHERE {{
+            {0} oboInOwl:hasExactSynonym ?lp .
+            ?bnode owl:annotatedSource {0} .
+            ?bnode oboInOwl:hasSynonymType <http://purl.obolibrary.org/obo/hp.owl#layperson> .
+            ?bnode owl:annotatedTarget ?lp .
+        }}
+    """.format(cls)
+    query_result = hpo_graph.query(lay_person_query)
+    if len(list(query_result)) > 0:
+        for res in query_result:
+            lay_synonyms.append(str(res[0]))
+    return lay_synonyms
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_flybase.py
+++ b/tests/test_flybase.py
@@ -20,45 +20,5 @@ class FlyBaseTestCase(SourceTestCase):
         self.source = None
         return
 
-    def testcvterms(self):
-        """
-        There's some cvterms we expect to stay constant that are coded against.
-        These are included and intended to be compared against their label,
-        and will fail if they change.
-        :return:
-        """
-        cvterm_list = {
-            136340: 'linked_image'
-        }
-
-        # TODO check if cvterm file is there first
-        import csv
-        line_counter = 0
-        raw = '/'.join((self.source.rawdir, 'cvterm'))
-        logger.info("processing cvterms")
-        cvterms_from_file = {}
-        with open(raw, 'r') as f:
-            f.readline()  # read the header row; skip
-            filereader = csv.reader(f, delimiter='\t', quotechar='\"')
-            for line in filereader:
-                line_counter += 1
-                (cvterm_id, cv_id, definition, dbxref_id, is_obsolete,
-                 is_relationshiptype, name) = line
-
-                cvterms_from_file[int(cvterm_id)] = name
-
-        for cvterm in cvterm_list:
-            self.assertTrue(
-                cvterm in cvterms_from_file,
-                "cvterm {0} not in file".format(cvterm))
-            self.assertTrue(
-                cvterm_list[cvterm] == cvterms_from_file[cvterm],
-                "cvterm name mismatch (expected:{0}, has:{1})".format(
-                    cvterm_list[cvterm], cvterms_from_file[cvterm]))
-
-        logger.info("All %d cvterms are as expected", len(cvterm_list))
-
-        return
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_gwascatalog.py
+++ b/tests/test_gwascatalog.py
@@ -291,35 +291,35 @@ class TestGwasHaplotypeModel(unittest.TestCase):
                         dbSNP:rs3758171,
                         dbSNP:rs3824344,
                         dbSNP:rs7020413 ;
-                OBO:GENO_0000418 <http://www.ncbi.nlm.nih.gov/gene/5079> ;
+                OBO:GENO_0000418 <http://identifiers.org/hgnc/HGNC:8619> ;
                 OBO:RO_0002162 OBO:NCBITaxon_9606 .
 
                 ?snp a OBO:SO_0000694,
                         OBO:SO_0001627 ;
                     rdfs:label "rs1329573-?" ;
                     faldo:location <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36998996-36998996-Region> ;
-                    OBO:GENO_0000418 <http://www.ncbi.nlm.nih.gov/gene/5079> ;
+                    OBO:GENO_0000418 <http://identifiers.org/hgnc/HGNC:8619> ;
                     OBO:RO_0002162 OBO:NCBITaxon_9606 .
 
                 dbSNP:rs3758171 a OBO:SO_0000694,
                         OBO:SO_0001627 ;
                     rdfs:label "rs3758171-?" ;
                     faldo:location <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36997420-36997420-Region> ;
-                    OBO:GENO_0000418 <http://www.ncbi.nlm.nih.gov/gene/5079> ;
+                    OBO:GENO_0000418 <http://identifiers.org/hgnc/HGNC:8619> ;
                     OBO:RO_0002162 OBO:NCBITaxon_9606 .
 
                 dbSNP:rs3824344 a OBO:SO_0000694,
                         OBO:SO_0001627 ;
                     rdfs:label "rs3824344-?" ;
                     faldo:location <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-37000690-37000690-Region> ;
-                    OBO:GENO_0000418 <http://www.ncbi.nlm.nih.gov/gene/5079> ;
+                    OBO:GENO_0000418 <http://identifiers.org/hgnc/HGNC:8619> ;
                     OBO:RO_0002162 OBO:NCBITaxon_9606 .
 
                 dbSNP:rs7020413 a OBO:SO_0000694,
                         OBO:SO_0001627 ;
                     rdfs:label "rs7020413-?" ;
                     faldo:location <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-37002118-37002118-Region> ;
-                    OBO:GENO_0000418 <http://www.ncbi.nlm.nih.gov/gene/5079> ;
+                    OBO:GENO_0000418 <http://identifiers.org/hgnc/HGNC:8619> ;
                     OBO:RO_0002162 OBO:NCBITaxon_9606 .
 
                 <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36997420-36997420-Region> a faldo:Region ;

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -126,4 +126,4 @@ class UDPTestCase(unittest.TestCase):
         sparql_output = udp.graph.query(sparql_query)
         results = list(sparql_output)
         expected = [(URIRef(udp.graph._getNode(":patient_1")),)]
-        #self.assertEqual(results, expected)
+        self.assertEqual(results, expected)

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -110,8 +110,6 @@ class UDPTestCase(unittest.TestCase):
         mock_file = mock_open(mock=mock_data)
         udp = UDP('rdf_graph', False)
 
-        # Fails 20161118 see issue 386?
-
         udp._parse_patient_variants(mock_file)
         sparql_query = """
             SELECT ?patient
@@ -120,7 +118,7 @@ class UDPTestCase(unittest.TestCase):
                     rdfs:label "patient_1 genotype" ;
                     OBO:GENO_0000382 [ a OBO:SO_0001059 ;
                         rdfs:label "hg19chr1(CLK2):g.155230432G>A" ;
-                        OBO:GENO_0000418 <http://www.ncbi.nlm.nih.gov/gene/1196> ;
+                        OBO:GENO_0000418 <http://identifiers.org/hgnc/HGNC:2069> ;
                         OBO:RO_0002162 OBO:NCBITaxon_9606 ;
                         owl:sameAs dbSNP:rs11557757 ] ] .
             }
@@ -128,4 +126,4 @@ class UDPTestCase(unittest.TestCase):
         sparql_output = udp.graph.query(sparql_query)
         results = list(sparql_output)
         expected = [(URIRef(udp.graph._getNode(":patient_1")),)]
-        self.assertEqual(results, expected)
+        #self.assertEqual(results, expected)


### PR DESCRIPTION
- Removed primary key reference for cvterm, replaces with join and matching on cvterm label
- Adjustment for 15th column in hpoa, note the hpoa file format will be refactored in the new year
- update udp test with hgnc instead of entrez gene
-  Fix mmrrc whitespace issue

Test runs:
http://ci.monarchinitiative.org/job/build-mmrrc-ttl/40/
http://ci.monarchinitiative.org/job/build-hpoa-ttl/53/
http://ci.monarchinitiative.org/job/build-flybase-ttl/76/