### PR TITLE
WIP: fix mychem, test refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,5 +37,8 @@ RGD-test:
 SGD-test:
 	$(TEST) tests/test_sgd.py
 
+CTD-test:
+	$(TEST) tests/test_ctd.py
+
 trans-test:
 	$(TEST) tests/test_trtable.py

--- a/dipper/graph/RDFGraph.py
+++ b/dipper/graph/RDFGraph.py
@@ -48,7 +48,7 @@ class RDFGraph(ConjunctiveGraph, DipperGraph):
                     (self._getNode(subject_id), self._getNode(predicate_id),
                      Literal(obj)))
             else:
-                logger.warn(
+                logger.warning(
                     "None as literal object for subj: %s and pred: %s",
                     subject_id, predicate_id)
         elif obj is not None and obj != '':
@@ -56,7 +56,7 @@ class RDFGraph(ConjunctiveGraph, DipperGraph):
                 (self._getNode(subject_id), self._getNode(predicate_id),
                  self._getNode(obj)))
         else:
-            logger.warn(
+            logger.warning(
                 "None/empty object IRI for subj: %s and pred: %s",
                 subject_id, predicate_id)
         return
@@ -65,7 +65,7 @@ class RDFGraph(ConjunctiveGraph, DipperGraph):
     def skolemizeBlankNode(self, curie):
         stripped_id = re.sub(r'^_:|^_', '', curie, 1)
         node = BNode(stripped_id).skolemize(self.curie_util.get_base())
-        node = re.sub(r'rdflib/', '', node)  # where does this come in??
+        node = re.sub(r'rdflib/', '', node)  # remove string added by rdflib
         return URIRef(node)
 
 

--- a/dipper/sources/CTD.py
+++ b/dipper/sources/CTD.py
@@ -96,7 +96,6 @@ class CTD(Source):
         else:
             self.test_diseaseids = config.get_config()['test_ids']['disease']
 
-        self.g = self.graph
         self.geno = Genotype(self.graph)
         self.pathway = Pathway(self.graph)
 
@@ -143,12 +142,8 @@ class CTD(Source):
         if self.testOnly:
             self.testMode = True
 
-        if self.testMode:
-            self.g = self.testgraph
-        else:
-            self.g = self.graph
-        self.geno = Genotype(self.g)
-        self.pathway = Pathway(self.g)
+        self.geno = Genotype(self.graph)
+        self.pathway = Pathway(self.graph)
 
         self._parse_ctd_file(
             limit, self.files['chemical_disease_interactions']['file'])
@@ -213,7 +208,7 @@ class CTD(Source):
         Returns:
             :return None
         """
-        model = Model(self.g)
+        model = Model(self.graph)
         self._check_list_len(row, 4)
         (gene_symbol, gene_id, pathway_name, pathway_id) = row
 
@@ -339,7 +334,7 @@ class CTD(Source):
         Returns:
             :return None
         """
-        model = Model(self.g)
+        model = Model(self.graph)
         self._check_list_len(row, 10)
         (chem_name, chem_id, cas_rn, disease_name, disease_id, direct_evidence,
          inferred_gene_symbol, inference_score, omim_ids, pubmed_ids) = row
@@ -404,7 +399,7 @@ class CTD(Source):
         # self._check_list_len(row, 9)
         # geno = Genotype(g)
         # gu = GraphUtils(curie_map.get())
-        model = Model(self.g)
+        model = Model(self.graph)
         (gene_symbol, gene_id, disease_name, disease_id, direct_evidence,
          inference_chemical_name, inference_score, omim_ids, pubmed_ids) = row
 
@@ -520,12 +515,12 @@ class CTD(Source):
         """
 
         # TODO pass in the relevant Assoc class rather than relying on G2P
-        assoc = G2PAssoc(self.g, self.name, subject_id, object_id, rel_id)
+        assoc = G2PAssoc(self.graph, self.name, subject_id, object_id, rel_id)
         if pubmed_ids is not None and len(pubmed_ids) > 0:
             eco = self._get_evidence_code('TAS')
             for pmid in pubmed_ids:
                 r = Reference(
-                    self.g, pmid, Reference.ref_types['journal_article'])
+                    self.graph, pmid, Reference.ref_types['journal_article'])
                 r.addRefToGraph()
                 assoc.add_source(pmid)
                 assoc.add_evidence(eco)
@@ -600,7 +595,7 @@ class CTD(Source):
         return class_map[clslab]
 
     def _parse_curated_chem_disease(self, limit):
-        model = Model(self.g)
+        model = Model(self.graph)
         line_counter = 0
         file_path = '/'.join(
             (self.rawdir, self.static_files['publications']['file']))
@@ -626,7 +621,7 @@ class CTD(Source):
                     pub_id = 'PMID:' + pub_id
                     r = Reference(
                         pub_id, Reference.ref_types['journal_article'])
-                    r.addRefToGraph(self.g)
+                    r.addRefToGraph(self.graph)
                     pubids = [pub_id]
                 else:
                     pubids = None

--- a/dipper/sources/GWASCatalog.py
+++ b/dipper/sources/GWASCatalog.py
@@ -65,7 +65,7 @@ class GWASCatalog(Source):
         super().__init__(graph_type, are_bnodes_skolemized, 'gwascatalog')
 
         if graph_type != 'rdf_graph':
-            raise ValueError("UDP requires a rdf_graph")
+            raise ValueError("GWAS Catalog requires a rdf_graph")
 
         self.dataset = Dataset(
             'gwascatalog', 'GWAS Catalog', 'http://www.ebi.ac.uk/gwas/',
@@ -116,13 +116,13 @@ class GWASCatalog(Source):
         """
         raw = '/'.join((self.rawdir, self.files['catalog']['file']))
         logger.info("Processing Data from %s", raw)
-        efo_ontology = RDFGraph(false, "EFO")
+        efo_ontology = RDFGraph(False, "EFO")
         logger.info("Loading EFO ontology in separate rdf graph")
         efo_ontology.parse(self.files['efo']['url'], format='xml')
         efo_ontology.bind_all_namespaces()
         logger.info("Finished loading EFO ontology")
 
-        so_ontology = RDFGraph(false, "SO")
+        so_ontology = RDFGraph(False, "SO")
         logger.info("Loading SO ontology in separate rdf graph")
         so_ontology.parse(self.files['so']['url'], format='xml')
         so_ontology.bind_all_namespaces()

--- a/dipper/sources/MyChem.py
+++ b/dipper/sources/MyChem.py
@@ -147,19 +147,15 @@ class MyChem(Source):
         return
 
     def fetch_from_mychem(self):
-        count = 0
         for k in self.inchikeys:
-            count +=1
-            if count < 10:
-                ids = ",".join(k)
-                fields = 'drugbank.targets,drugbank.drugbank_id,unii.unii,drugcentral.drug_use,drugcentral.bioactivity'
-                records = MyChem.get_drug_record(ids=ids, fields=fields)
-                for record in records:
-                    if 'drugbank' in record.keys():
-                        self.drugbank_targets.append(record)
-                    if 'drugcentral' in record.keys():
-                        self.drugcentral_interactors.append(record)
-            return
+            ids = ",".join(k)
+            fields = 'drugbank.targets,drugbank.drugbank_id,unii.unii,drugcentral.drug_use,drugcentral.bioactivity'
+            records = MyChem.get_drug_record(ids=ids, fields=fields)
+            for record in records:
+                if 'drugbank' in record.keys():
+                    self.drugbank_targets.append(record)
+                if 'drugcentral' in record.keys():
+                    self.drugcentral_interactors.append(record)
 
     @staticmethod
     def add_relation(results, relation):

--- a/dipper/utils/CurieUtil.py
+++ b/dipper/utils/CurieUtil.py
@@ -63,4 +63,4 @@ class CurieUtil(object):
 
     # what to do if the default base curie ":" does not exist??
     def get_base(self):
-        self.curie_map.get("")
+        return self.curie_map.get("")

--- a/dipper/utils/TestUtils.py
+++ b/dipper/utils/TestUtils.py
@@ -1,57 +1,39 @@
-import os
 import logging
-import sys
-from rdflib import Graph
+import io
+from dipper.graph.RDFGraph import RDFGraph
+from unittest.mock import patch, mock_open
 
 logger = logging.getLogger(__name__)
 
 
 class TestUtils:
 
-    def __init__(self, graph=None):
-        # instantiate source object
-        self.graph = graph
-        if self.graph is None:
-            self.graph = Graph()
+    def test_graph_equality(self, turtlish, graph):
+        """
 
-        return
+        :param turtlish: String of triples in turtle
+                         format without prefix header
+        :param graph: Graph object to test agaisnt
+        :return: Boolean, True if graphs contain same
+                          set of triples
+        """
+        turtle_graph = RDFGraph()
+        turtle_graph.bind_all_namespaces()
+        prefixes = ["@prefix {}: <{}> .".format(n[0], n[1])
+                    for n in turtle_graph.namespace_manager.namespaces()]
+        prefix_lines = "\n".join(prefixes)
 
-    def query_graph(self, query, is_formatted=False):
-        query_result = self.graph.query(query)
-        output = []
-        for row in query_result:
-            result_set = []
-            for val in row:
-                if val is None:
-                    val = 'null'
-                result_set.append(val)
-            if is_formatted:
-                output.append(", ".join(result_set))
-            else:
-                output.append(result_set)
-
-        return output
-
-    def check_query_syntax(self, query, source):
-        source.graph.query(query)
-        return
-
-    def load_graph_from_turtle(self, source):
-        file = source.outdir+'/'+source.name+'.ttl'
-        if not os.path.exists(file):
-            logger.error("file: %s does not exist", file)
-            sys.exit(1)
-        # load turtle file into graph
-        self.graph.parse(file, format="turtle")
-
-        return
-
-    def load_testgraph_from_turtle(self, source):
-        file = source.outdir+'/'+source.name+'_test.ttl'
-        if not os.path.exists(file):
-            logger.error("file: %s does not exist", file)
-            sys.exit(1)
-        # load turtle file into graph
-        self.graph.parse(file, format="turtle")
-
-        return
+        turtle_string = prefix_lines + turtlish
+        mock_file = io.StringIO(turtle_string)
+        turtle_graph.parse(mock_file, format="turtle")
+        turtle_triples = set(list(turtle_graph))
+        ref_triples = set(list(graph))
+        equality = turtle_triples == ref_triples
+        if not equality:
+            logger.warning("Triples do not match\n"
+                           "Left hand difference: {}\n"
+                           "Right hand difference:{}".format(
+                turtle_triples - ref_triples,
+                ref_triples - turtle_triples
+            ))
+        return equality

--- a/tests/resources/mychem.json
+++ b/tests/resources/mychem.json
@@ -1,0 +1,27 @@
+{
+   "drugbank":{
+      "_license":"https://goo.gl/kvVASD",
+      "drugbank_id":"DB13259"
+   },
+   "query":"HRYZWHHZPQKTII-UHFFFAOYSA-N",
+   "drugcentral":{
+      "_license":"https://goo.gl/QDNyNe",
+      "drug_use":[
+         {
+            "relation":"contraindication",
+            "snomed_id":"30911005",
+            "snomed_name":"Cryoglobulinemia"
+         },
+         {
+            "relation":"indication",
+            "snomed_id":"386761002",
+            "snomed_name":"Local anesthesia"
+         }
+      ]
+   },
+   "_id":"HRYZWHHZPQKTII-UHFFFAOYSA-N",
+   "unii":{
+      "_license":"?",
+      "unii":"46U771ERWK"
+   }
+}

--- a/tests/test_ctd.py
+++ b/tests/test_ctd.py
@@ -2,18 +2,30 @@
 import unittest
 import logging
 from dipper.sources.CTD import CTD
-from dipper.models.assoc.G2PAssoc import G2PAssoc
-from tests.test_source import SourceTestCase
+from dipper.graph.RDFGraph import RDFGraph
+from dipper.utils.TestUtils import TestUtils
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
 
-class CTDTestCase(SourceTestCase):
+class CTDTestCase(unittest.TestCase):
     def setUp(self):
+        self.test_util = TestUtils()
         self.source = CTD('rdf_graph', True)
-        self.source.settestonly(True)
-        self._setDirToSource()
+        self.source.graph = RDFGraph(True)
+        self.test_row = [
+            'Nicotine',
+            'D009538',
+            '',
+            'TOBACCO ADDICTION, SUSCEPTIBILITY TO',
+            'OMIM:188890',
+            'therapeutic',
+            '',
+            '',
+            '',
+            '12345|56789'
+        ]
         return
 
     def tearDown(self):
@@ -21,56 +33,32 @@ class CTDTestCase(SourceTestCase):
         return
 
     def test_therapeutic_relationship(self):
-        from dipper.utils.TestUtils import TestUtils
-        from dipper.models.Model import Model
+        # test that graph is empty
+        self.assertTrue(len(list(self.source.graph)) == 0)
 
-        # Make testutils object and load ttl
-        test_query = TestUtils(self.source.graph)
-        test_query.load_testgraph_from_turtle(self.source)
-        graph = self.source.graph
-        model = Model(graph)
+        self.source._process_interactions(self.test_row)
 
-        # Expected structure
-        # TODO can this be unified OBAN and the Annot models
-        # to be automatically generated?
-        sparql_query = """
-                       SELECT ?assoc ?disease ?rel ?chemical
-                       WHERE {
-                           ?assoc a OBAN:association ;
-                           OBAN:association_has_object ?disease ;
-                           OBAN:association_has_predicate ?rel ;
-                           OBAN:association_has_subject ?chemical .}
-                       """
+        triples = """
+            :MONARCH_b6dc57a9a048c751 a OBAN:association ;
+                RO:0002558 ECO:0000033 ;
+                dc:source PMID:12345, PMID:56789 ;
+                OBAN:association_has_object OMIM:188890 ;
+                OBAN:association_has_predicate RO:0002606 ;
+                OBAN:association_has_subject MESH:D009538 .
+            
+            MESH:D009538 a owl:Class ;
+                rdfs:label "Nicotine" ;
+                RO:0002606 OMIM:188890 .
+                
+            PMID:12345 a IAO:0000013 .
+            PMID:56789 a IAO:0000013 .
+            
+            OMIM:188890 a owl:Class .
+        """
+        # test exact contents of graph
+        self.assertTrue(self.test_util.test_graph_equality(
+            triples, self.source.graph))
 
-        # SPARQL variables to check
-        chem_id = 'MESH:D009538'
-        chem_uri = graph._getNode(chem_id)
-        disease_id = 'OMIM:188890'
-        disease_uri = graph._getNode(disease_id)
-        rel_id = model.object_properties['substance_that_treats']
-        rel_uri = graph._getNode(rel_id)
-        # TODO unused
-        # pubmed_id = 'PMID:16785264'
-        # pubmed_uri = gu.getNode(pubmed_id)
-        # eco = 'ECO:0000033'
-
-        assoc = G2PAssoc(graph, self.source.name, chem_id, disease_id, rel_id)
-        assoc_id = assoc.make_g2p_id()
-        assoc_uri = self.source.graph._getNode(assoc_id)
-
-        # One of the expected outputs from query
-        expected_output = [assoc_uri, disease_uri, rel_uri, chem_uri]
-
-        # Query graph
-        sparql_output = test_query.query_graph(sparql_query)
-
-        self.assertTrue(
-            expected_output in sparql_output,
-            "did not find expected association: " + str(expected_output) +
-            " found " +
-            str(len(sparql_output)) + " others:\n" + str(sparql_output))
-
-        logger.info("Test query data finished.")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_gwascatalog.py
+++ b/tests/test_gwascatalog.py
@@ -5,24 +5,10 @@ import logging
 from tests.test_source import SourceTestCase
 from dipper.sources.GWASCatalog import GWASCatalog
 from dipper.graph.RDFGraph import RDFGraph
-from rdflib import URIRef
+from dipper.utils.TestUtils import TestUtils
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
-
-
-class GWASCatalogTestCase(SourceTestCase):
-
-    def setUp(self):
-        self.source = GWASCatalog('rdf_graph', True)
-        self.source.test_ids = self._get_conf()['test_ids']
-        self.source.settestonly(True)
-        self._setDirToSource()
-        return
-
-    def tearDown(self):
-        self.source = None
-        return
 
 
 class TestGwasSNPModel(unittest.TestCase):
@@ -32,7 +18,10 @@ class TestGwasSNPModel(unittest.TestCase):
     """
 
     def setUp(self):
+        self.test_util = TestUtils()
         self.source = GWASCatalog('rdf_graph', True)
+        self.source.graph = RDFGraph(True) # Reset graph
+        self.source.graph.bind_all_namespaces()
         self.test_data = {
             'snp_label': 'rs1491921-C',
             'chrom_num': '5',
@@ -63,6 +52,7 @@ class TestGwasSNPModel(unittest.TestCase):
         Given the label: rs1491921-C
         return dbSNP:rs1491921, snp
         """
+        self.assertTrue(len(list(self.source.graph)) == 0)
         variant_curie, variant_type = \
             self.source._get_curie_and_type_from_id(self.test_data['snp_label'])
 
@@ -73,6 +63,7 @@ class TestGwasSNPModel(unittest.TestCase):
         """
         Test output model of _add_snp_to_graph()
         """
+        self.assertTrue(len(list(self.source.graph)) == 0)
         variant_curie, variant_type = \
             self.source._get_curie_and_type_from_id(self.test_data['snp_label'])
 
@@ -81,42 +72,34 @@ class TestGwasSNPModel(unittest.TestCase):
             self.test_data['chrom_pos'], self.test_data['context'],
             self.test_data['allele_freq'])
 
-        sparql_query = """
-SELECT ?snp
-WHERE {
-    ?snp a OBO:SO_0000694, OBO:SO_0001628 ;
+        triples = """
+    dbSNP:rs1491921 a OBO:SO_0000694, OBO:SO_0001628 ;
         rdfs:label "rs1491921-C" ;
-        faldo:location  _:GRCh38chr5-21259029-21259029-Region ;
+        faldo:location  <https://monarchinitiative.org/.well-known/genid/GRCh38chr5-21259029-21259029-Region> ;
         OBO:RO_0002162 OBO:NCBITaxon_9606 ;
         dc:description "0.013 [risk allele frequency]" .
 
-    _:GRCh38chr5-21259029-21259029-Region a faldo:Region ;
-        faldo:begin _:GRCh38chr5-21259029 ;
-        faldo:end _:GRCh38chr5-21259029 .
+    <https://monarchinitiative.org/.well-known/genid/GRCh38chr5-21259029-21259029-Region> a faldo:Region ;
+        faldo:begin <https://monarchinitiative.org/.well-known/genid/GRCh38chr5-21259029> ;
+        faldo:end <https://monarchinitiative.org/.well-known/genid/GRCh38chr5-21259029> .
 
-    _:GRCh38chr5-21259029 a faldo:Position ;
+    <https://monarchinitiative.org/.well-known/genid/GRCh38chr5-21259029> a faldo:Position ;
         faldo:position 21259029 ;
         faldo:reference OBO:CHR_GRCh38chr5 .
-}
 """
-        # <https://monarchinitiative.org/.well-known/genid/
-
         # To debug
         #print(self.source.graph.serialize(format="turtle").decode("utf-8"))
         #self.assertTrue(False)
 
-        sparql_output = self.source.graph.query(sparql_query)
-        # Test that query passes and returns one row
-        results = list(sparql_output)
-        expected = [(URIRef(self.source.graph._getNode("dbSNP:rs1491921")),)]
-        self.assertEqual(results, expected)
+        self.assertTrue(self.test_util.test_graph_equality(
+            triples, self.source.graph))
 
     def test_snp_gene_relation(self):
         """
         test the _add_snp_gene_relation function
         :return:
         """
-
+        self.assertTrue(len(list(self.source.graph)) == 0)
         variant_curie, variant_type = \
             self.source._get_curie_and_type_from_id(
                 self.test_data['snp_label'])
@@ -126,26 +109,19 @@ WHERE {
             self.test_data['upstream_gene_num'],
             self.test_data['downstream_gene_num'])
 
-        self.source.graph.bind("NCBIGene", "http://www.ncbi.nlm.nih.gov/gene/")
-
-        sparql_query = """
-SELECT ?snp
-WHERE {
-    ?snp OBO:RO_0002528 NCBIGene:107986180 ;
-         OBO:RO_0002529 NCBIGene:107986179 .
-}
-"""
-        sparql_output = self.source.graph.query(sparql_query)
-        # Test that query passes and returns one row
-        results = list(sparql_output)
-        expected = [(URIRef(self.source.graph._getNode("dbSNP:rs1491921")),)]
-        self.assertEqual(results, expected)
+        triples = """
+        dbSNP:rs1491921 OBO:RO_0002528 NCBIGene:107986180 ;
+            OBO:RO_0002529 NCBIGene:107986179 .
+        """
+        self.assertTrue(self.test_util.test_graph_equality(
+            triples, self.source.graph))
 
     def test_deprecated_snp(self):
         """
         test the _add_deprecated_snp
         :return:
         """
+        self.assertTrue(len(list(self.source.graph)) == 0)
         #fake data
         snp_id_current = '12345'
         merged = '1'
@@ -157,27 +133,22 @@ WHERE {
             variant_curie, snp_id_current, merged,
             self.test_data['chrom_num'], self.test_data['chrom_pos'])
 
-        sparql_query = """
-SELECT ?snp
-    WHERE {
-        ?snp a owl:NamedIndividual ;
+        triples = """
+        dbSNP:rs1491921 a owl:NamedIndividual ;
             OBO:IAO_0100001 dbSNP:rs12345 ;
             owl:deprecated true .
 
         dbSNP:rs12345 MONARCH:cliqueLeader true .
-    }
-"""
-        sparql_output = self.source.graph.query(sparql_query)
-        # Test that query passes and returns one row
-        results = list(sparql_output)
-        expected = [(URIRef(self.source.graph._getNode("dbSNP:rs1491921")),)]
-        self.assertEqual(results, expected)
+        """
+        self.assertTrue(self.test_util.test_graph_equality(
+            triples, self.source.graph))
 
     def test_snp_trait_association(self):
         """
         test the _add_variant_trait_association
         :return:
         """
+        self.assertTrue(len(list(self.source.graph)) == 0)
         efo_ontology = RDFGraph()
         logger.info("Loading EFO ontology in separate rdf graph")
         efo_ontology.parse(self.source.files['efo']['url'], format='xml')
@@ -196,39 +167,35 @@ SELECT ?snp
             variant_curie, self.test_data['trait_uri'], efo_ontology,
             self.test_data['pubmed'], description)
 
-        sparql_query = """
-SELECT ?snp
-WHERE {{
+        triples = """
     MONARCH:b46cdf48950cb00d a OBAN:association ;
-        dc:description "{}" ;
+        dc:description "{0}" ;
         OBO:RO_0002558 OBO:ECO_0000213 ;
         dc:source PMID:25918132 ;
         OBAN:association_has_object EFO:0003949 ;
         OBAN:association_has_predicate OBO:RO_0002326 ;
-        OBAN:association_has_subject ?snp .
+        OBAN:association_has_subject dbSNP:rs1491921 .
 
     MONARCH:70a05d8eb1c3d4b0 a OBAN:association ;
+        dc:description "{0}" ;
         OBO:RO_0002558 OBO:ECO_0000213 ;
         dc:source PMID:25918132 ;
         OBAN:association_has_object EFO:0006995 ;
         OBAN:association_has_predicate OBO:RO_0002326 ;
-        OBAN:association_has_subject ?snp .
+        OBAN:association_has_subject dbSNP:rs1491921 .
 
     EFO:0003949 a owl:Class ;
         rdfs:label "eye color"^^xsd:string ;
         rdfs:subClassOf UPHENO:0001001 .
 
-    ?snp OBO:RO_0002326 EFO:0003949,
+    dbSNP:rs1491921 OBO:RO_0002326 EFO:0003949,
             EFO:0006995 .
 
     PMID:25918132 a OBO:IAO_0000013 .
-}}
         """.format(description)
-        sparql_output = self.source.graph.query(sparql_query)
-        # Test that query passes and returns one row
-        results = list(sparql_output)
-        expected = [(URIRef(self.source.graph._getNode("dbSNP:rs1491921")),)]
-        self.assertEqual(results, expected)
+
+        self.assertTrue(self.test_util.test_graph_equality(
+            triples, self.source.graph))
 
 
 class TestGwasHaplotypeModel(unittest.TestCase):
@@ -238,7 +205,9 @@ class TestGwasHaplotypeModel(unittest.TestCase):
     """
 
     def setUp(self):
+        self.test_util = TestUtils()
         self.source = GWASCatalog('rdf_graph', True)
+        self.source.graph = RDFGraph(True)
         self.test_data = {
             'snp_label': 'rs1329573-?; rs7020413-?; rs3824344-?; rs3758171-?',
             'chrom_num': '9;9;9;9',
@@ -271,6 +240,7 @@ class TestGwasHaplotypeModel(unittest.TestCase):
                             chrom_num, chrom_pos, context,
                             risk_allele_frequency, mapped_gene, so_ontology)
         """
+        self.assertTrue(len(list(self.source.graph)) == 0)
         variant_curie, variant_type = \
             self.source._get_curie_and_type_from_id(self.test_data['snp_label'])
 
@@ -285,91 +255,78 @@ class TestGwasHaplotypeModel(unittest.TestCase):
             self.test_data['chrom_pos'], self.test_data['context'],
             self.test_data['allele_freq'], self.test_data['mapped_gene'], so_ontology)
 
-            # bind('HGNC', 'http://identifiers.org/hgnc/HGNC:')
+        triples = """
+:haplotype_bcb627b1f64039b0 a OBO:GENO_0000871 ;
+    rdfs:label "rs1329573-?; rs7020413-?; rs3824344-?; rs3758171-?" ;
+    OBO:GENO_0000382 dbSNP:rs1329573,
+        dbSNP:rs3758171,
+        dbSNP:rs3824344,
+        dbSNP:rs7020413 ;
+    OBO:GENO_0000418 HGNC:8619 ;
+    OBO:RO_0002162 OBO:NCBITaxon_9606 .
 
-        sparql_query = """
-SELECT ?snp
-    WHERE {
-        ?snp a OBO:SO_0000694, OBO:SO_0001627 ;
-            rdfs:label "rs1329573-?" ;
-            faldo:location _:GRCh38chr9-36998996-36998996-Region ;
-            OBO:GENO_0000418 HGNC:8619 ;
-            OBO:RO_0002162 OBO:NCBITaxon_9606 .
-    }
-"""
+dbSNP:rs1329573 a OBO:SO_0000694,
+        SO:0001627 ;
+    rdfs:label "rs1329573-?" ;
+    faldo:location <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36998996-36998996-Region> ;
+    OBO:GENO_0000418 HGNC:8619 ;
+    OBO:RO_0002162 OBO:NCBITaxon_9606 .
 
-        # the rest of this looks impressive but matters little
-        # requesting something which does not exist
-        # does not generate an error
+dbSNP:rs3758171 a OBO:SO_0000694,
+        OBO:SO_0001627 ;
+    rdfs:label "rs3758171-?" ;
+    faldo:location <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36997420-36997420-Region> ;
+    OBO:GENO_0000418 HGNC:8619 ;
+    OBO:RO_0002162 OBO:NCBITaxon_9606 .
 
-        #MONARCH:haplotype_bcb627b1f64039b0 a OBO:GENO_0000871 ;
-            #rdfs:label "rs1329573-?; rs7020413-?; rs3824344-?; rs3758171-?" ;
-            #OBO:GENO_0000382 ?snp,
-                #dbSNP:rs3758171,
-                #dbSNP:rs3824344,
-                #dbSNP:rs7020413 ;
-        #OBO:GENO_0000418 HGNC:8619 ;
-        #OBO:RO_0002162 OBO:NCBITaxon_9606 .
+dbSNP:rs3824344 a OBO:SO_0000694,
+        OBO:SO_0001627 ;
+    rdfs:label "rs3824344-?" ;
+    faldo:location <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-37000690-37000690-Region> ;
+    OBO:GENO_0000418 HGNC:8619 ;
+    OBO:RO_0002162 OBO:NCBITaxon_9606 .
 
-        #dbSNP:rs3758171 a OBO:SO_0000694,
-                #OBO:SO_0001627 ;
-            #rdfs:label "rs3758171-?" ;
-            #faldo:location _:GRCh38chr9-36997420-36997420-Region ;
-            #OBO:GENO_0000418 HGNC:8619 ;
-            #OBO:RO_0002162 OBO:NCBITaxon_9606 .
+dbSNP:rs7020413 a OBO:SO_0000694,
+        OBO:SO_0001627 ;
+    rdfs:label "rs7020413-?" ;
+    faldo:location <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-37002118-37002118-Region> ;
+    OBO:GENO_0000418 HGNC:8619 ;
+    OBO:RO_0002162 OBO:NCBITaxon_9606 .
 
-        #dbSNP:rs3824344 a OBO:SO_0000694,
-                #OBO:SO_0001627 ;
-            #rdfs:label "rs3824344-?" ;
-            #faldo:location :_GRCh38chr9-37000690-37000690-Region ;
-            #OBO:GENO_0000418 HGNC:8619 ;
-            #OBO:RO_0002162 OBO:NCBITaxon_9606 .
+<https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36997420-36997420-Region> a faldo:Region ;
+    faldo:begin <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36997420> ;
+    faldo:end <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36997420> .
 
-        #dbSNP:rs7020413 a OBO:SO_0000694,
-                #OBO:SO_0001627 ;
-            #rdfs:label "rs7020413-?" ;
-            #faldo:location _:GRCh38chr9-37002118-37002118-Region ;
-            #OBO:GENO_0000418 HGNC:8619 ;
-            #OBO:RO_0002162 OBO:NCBITaxon_9606 .
+<https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36998996-36998996-Region> a faldo:Region ;
+    faldo:begin <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36998996> ;
+    faldo:end <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36998996> .
 
-        #_:GRCh38chr9-36997420-36997420-Region a faldo:Region ;
-            #faldo:begin _:GRCh38chr9-36997420> ;
-            #faldo:end _:GRCh38chr9-36997420> .
+<https://monarchinitiative.org/.well-known/genid/GRCh38chr9-37000690-37000690-Region> a faldo:Region ;
+    faldo:begin <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-37000690> ;
+    faldo:end <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-37000690> .
 
-        #_:GRCh38chr9-36998996-36998996-Region a faldo:Region ;
-            #faldo:begin _:GRCh38chr9-36998996> ;
-            #faldo:end _:GRCh38chr9-36998996> .
+<https://monarchinitiative.org/.well-known/genid/GRCh38chr9-37002118-37002118-Region> a faldo:Region ;
+    faldo:begin <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-37002118> ;
+    faldo:end <https://monarchinitiative.org/.well-known/genid/GRCh38chr9-37002118> .
 
-        #_:GRCh38chr9-37000690-37000690-Region a faldo:Region ;
-            #faldo:begin _:GRCh38chr9-37000690> ;
-            #faldo:end _:GRCh38chr9-37000690> .
+<https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36997420> a faldo:Position ;
+    faldo:position 36997420 ;
+    faldo:reference OBO:CHR_GRCh38chr9 .
 
-        #_:GRCh38chr9-37002118-37002118-Region> a faldo:Region ;
-            #faldo:begin _:GRCh38chr9-37002118> ;
-            #faldo:end _:GRCh38chr9-37002118> .
+<https://monarchinitiative.org/.well-known/genid/GRCh38chr9-36998996> a faldo:Position ;
+    faldo:position 36998996 ;
+    faldo:reference OBO:CHR_GRCh38chr9 .
 
-        #_:GRCh38chr9-36997420 a faldo:Position ;
-            #faldo:position 36997420 ;
-            #faldo:reference OBO:CHR_GRCh38chr9 .
+<https://monarchinitiative.org/.well-known/genid/GRCh38chr9-37000690> a faldo:Position ;
+    faldo:position 37000690 ;
+    faldo:reference OBO:CHR_GRCh38chr9 .
 
-        #_:GRCh38chr9-36998996 a faldo:Position ;
-            #faldo:position 36998996 ;
-            #faldo:reference OBO:CHR_GRCh38chr9 .
-
-        #_:GRCh38chr9-37000690 a faldo:Position ;
-            #faldo:position 37000690 ;
-            #faldo:reference OBO:CHR_GRCh38chr9 .
-
-        #_:GRCh38chr9-37002118 a faldo:Position ;
-            #faldo:position 37002118 ;
-            #faldo:reference OBO:CHR_GRCh38chr9 .
-    #}
-        #"""
-        sparql_output = self.source.graph.query(sparql_query)
-        # Test that query passes and returns one row
-        results = list(sparql_output)
-        expected = [(URIRef(self.source.graph._getNode("dbSNP:rs1329573")),)]
-        self.assertEqual(results, expected)
+<https://monarchinitiative.org/.well-known/genid/GRCh38chr9-37002118> a faldo:Position ;
+    faldo:position 37002118 ;
+    faldo:reference OBO:CHR_GRCh38chr9 .
+        """
+        self.assertTrue(self.test_util.test_graph_equality(
+            triples, self.source.graph))
 
 
 if __name__ == '__main__':

--- a/tests/test_mychem.py
+++ b/tests/test_mychem.py
@@ -1,0 +1,20 @@
+import json
+import unittest
+from dipper.sources.MyChem import MyChem
+from dipper.graph.RDFGraph import RDFGraph
+
+RESOURCE = ""
+
+class TestGwasSNPModel(unittest.TestCase):
+    """
+    Test the modelling of a  SNP to trait association
+    from sample GWAS catalog data
+    """
+
+    def setUp(self):
+        self.source = MyChem('rdf_graph', True)
+        self.source.graph = RDFGraph(True) # Reset graph
+        self.test_data = ""
+
+    def tearDown(self):
+        self.source = None

--- a/tests/test_reactome.py
+++ b/tests/test_reactome.py
@@ -2,11 +2,14 @@
 
 import unittest
 from dipper.sources.Reactome import Reactome
+from dipper.utils.TestUtils import TestUtils
+from dipper.graph.RDFGraph import RDFGraph
 
 
 class ReactomeTestCase(unittest.TestCase):
 
     def setUp(self):
+        self.test_util = TestUtils()
         self.test_set_1 = \
             ('ENSBTAP00000013354', 'R-BTA-3000480',
              'http://www.reactome.org/PathwayBrowser/#/R-BTA-3000480',
@@ -18,30 +21,29 @@ class ReactomeTestCase(unittest.TestCase):
 
     def testEnsemblReactomeParser(self):
         reactome = Reactome('rdf_graph', True)
+        reactome.graph = RDFGraph(True)
+        self.assertTrue(len(list(reactome.graph)) == 0)
+
         eco_map = Reactome.get_eco_map(Reactome.map_files['eco_map'])
         (gene, pathway_id, pathway_iri, pathway_label,
          go_ecode, species_name) = self.test_set_1
-        reactome._add_component_pathway_association(eco_map, gene, 'ENSEMBL', pathway_id,
-                                                    'REACT', pathway_label, go_ecode)
+        reactome._add_component_pathway_association(
+            eco_map, gene, 'ENSEMBL', pathway_id,
+            'REACT', pathway_label, go_ecode)
 
-        sparql_query = """
-                      SELECT ?assoc
-                      WHERE {
-                           ENSEMBL:ENSBTAP00000013354 OBO:RO_0002331 REACT:R-BTA-3000480 .
+        triples = """
+        ENSEMBL:ENSBTAP00000013354 RO:0002331 REACT:R-BTA-3000480 .
+        
+        :MONARCH_6582c188b7ec2001 a OBAN:association ;
+            OBO:RO_0002558 ECO:0000501 ;
+            OBAN:association_has_object REACT:R-BTA-3000480 ;
+            OBAN:association_has_predicate RO:0002331 ;
+            OBAN:association_has_subject ENSEMBL:ENSBTAP00000013354 .
 
-                           ?assoc a OBAN:association ;
-                               OBO:RO_0002558 OBO:ECO_0000501 ;
-                               OBAN:association_has_object REACT:R-BTA-3000480 ;
-                               OBAN:association_has_predicate OBO:RO_0002331 ;
-                               OBAN:association_has_subject ENSEMBL:ENSBTAP00000013354 .
-
-                           REACT:R-BTA-3000480 a owl:Class ;
-                               rdfs:label "Scavenging by Class A Receptors" ;
-                               rdfs:subClassOf OBO:GO_0009987,
-                                   OBO:PW_0000001 .
-
-                      }
-                      """
-        sparql_output = reactome.graph.query(sparql_query)
-
-        self.assertEqual(len(list(sparql_output)), 1)
+        REACT:R-BTA-3000480 a owl:Class ;
+            rdfs:label "Scavenging by Class A Receptors" ;
+            rdfs:subClassOf GO:0009987,
+            PW:0000001 .
+        """
+        self.assertTrue(self.test_util.test_graph_equality(
+            triples, reactome.graph))

--- a/tests/test_sgd.py
+++ b/tests/test_sgd.py
@@ -2,101 +2,13 @@
 
 import unittest
 from dipper.sources.SGD import SGD
+from dipper.utils.TestUtils import TestUtils
+from dipper.graph.RDFGraph import RDFGraph
 
-test_set = [
-    {'Allele': 'atp6-L183R (L183R)',
-     'Chemical': 'glycerol',
-     'Condition': 'elevated temperature (35 deg C)|nonfermentable carbon source',
-     'Details': 'similar results obtained with atp6-L247R, and atp6-W136R, all '
-                'corresponding to human NARP syndrome mutants',
-     'Experiment Type': 'classical genetics',
-     'Feature Name': 'Q0085',
-     'Feature Type': 'ORF',
-     'Gene Name': 'ATP6',
-     'Mutant Type': 'reduction of function',
-     'Phenotype': 'respiratory growth: decreased rate',
-     'Reference': 'PMID: 21715656|SGD_REF: S000145858',
-     'Reporter': ' ',
-     'SGDID': 'S000007268',
-     'Strain Background': 'Other'},
-    {'Allele': 'atp6-S250P (mutation analogous to a human MT-ATP6 mutation found '
-               'in multiple patients with LS, NARP, CMT or spinocerebellar ataxia)',
-     'Chemical': 'oligomycin (0.25 ug/ml)',
-     'Condition': ' ',
-     'Details': ' ',
-     'Experiment Type': 'classical genetics',
-     'Feature Name': 'Q0085',
-     'Feature Type': 'ORF',
-     'Gene Name': 'ATP6',
-     'Mutant Type': 'reduction of function',
-     'Phenotype': 'resistance to chemicals: decreased',
-     'Reference': 'PMID: 24316278|SGD_REF: S000156155',
-     'Reporter': ' ',
-     'SGDID': 'S000007268',
-     'Strain Background': 'Other'},
-    {'Allele': 'atp6-S250P (mutation analogous to a human MT-ATP6 mutation found '
-               'in multiple patients with LS, NARP, CMT or spinocerebellar ataxia)',
-     'Chemical': ' ',
-     'Condition': ' ',
-     'Details': ' ',
-     'Experiment Type': 'classical genetics',
-     'Feature Name': 'Q0085',
-     'Feature Type': 'ORF',
-     'Gene Name': 'ATP6',
-     'Mutant Type': 'reduction of function',
-     'Phenotype': 'respiratory growth: normal',
-     'Reference': 'PMID: 24316278|SGD_REF: S000156155',
-     'Reporter': ' ',
-     'SGDID': 'S000007268',
-     'Strain Background': 'Other'},
-    {'Allele': 'atp6-L252P (mutation analogous to a human MT-ATP6 mutation found '
-               'in a patient with severe Leigh syndrome)',
-     'Chemical': ' ',
-     'Condition': ' ',
-     'Details': ' ',
-     'Experiment Type': 'classical genetics',
-     'Feature Name': 'Q0085',
-     'Feature Type': 'ORF',
-     'Gene Name': 'ATP6',
-     'Mutant Type': 'reduction of function',
-     'Phenotype': 'respiratory growth: absent',
-     'Reference': 'PMID: 24316278|SGD_REF: S000156155',
-     'Reporter': ' ',
-     'SGDID': 'S000007268',
-     'Strain Background': 'Other'},
-    {'Allele': 'atp6-L183R (L183R)',
-     'Chemical': ' ',
-     'Condition': ' ',
-     'Details': ' ',
-     'Experiment Type': 'classical genetics',
-     'Feature Name': 'Q0085',
-     'Feature Type': 'ORF',
-     'Gene Name': 'ATP6',
-     'Mutant Type': 'unspecified',
-     'Phenotype': 'respiratory growth: decreased rate',
-     'Reference': 'PMID: 17855363|SGD_REF: S000124079',
-     'Reporter': ' ',
-     'SGDID': 'S000007268',
-     'Strain Background': 'Other (MR6)'},
-    {'Allele': 'atp6-L247R (L247R; equivalent to pathogenic mutation in human '
-               'ATP6)',
-     'Chemical': 'oligomycin (0.25 ug/ml)',
-     'Condition': 'nonfermentable carbon source (2% glycerol)',
-     'Details': ' ',
-     'Experiment Type': 'classical genetics',
-     'Feature Name': 'Q0085',
-     'Feature Type': 'ORF',
-     'Gene Name': 'ATP6',
-     'Mutant Type': 'unspecified',
-     'Phenotype': 'resistance to chemicals: decreased',
-     'Reference': 'PMID: 20056103|SGD_REF: S000132686',
-     'Reporter': ' ',
-     'SGDID': 'S000007268',
-     'Strain Background': 'Other'}
-]
 
 class SGDTestCase(unittest.TestCase):
     def setUp(self):
+        self.test_util = TestUtils()
         self.test_set_1 = {'Allele': 'atp6-L183R (L183R)',
                            'Chemical': 'glycerol',
                            'Condition': 'elevated temperature (35 deg C)|nonfermentable carbon source',
@@ -120,18 +32,45 @@ class SGDTestCase(unittest.TestCase):
 
     def testSGDParser(self):
         sgd = SGD('rdf_graph', True)
-        sgd.make_association(record=self.test_set_1)
-        sparql_query = """
-        SELECT ?assoc WHERE {
-        ?assoc a OBAN:association ;
+        sgd.graph = RDFGraph(True)
+        record = self.test_set_1
+        sgd.make_association(record)
+
+        description = [
+            'genomic_background: {}'.format(record['Strain Background']),
+            'allele: {}'.format(record['Allele']),
+            'chemical: {}'.format(record['Chemical']),
+            'condition: {}'.format(record['Condition']),
+            'details: {}'.format(record['Details']),
+            'feature_name: {}'.format(record['Feature Name']),
+            'gene_name: {}'.format(record['Gene Name']),
+            'mutant_type: {}'.format(record['Mutant Type']),
+            'reporter: {}'.format(record['Reporter']),
+        ]
+        description = " | ".join(description).strip()
+
+        triples = """
+        :MONARCH_95158d413dd73476 a OBAN:association ;
             OBO:RO_0002558 OBO:APO_0000020 ;
-            dc:description ?description;
-            OBAN:association_has_object <https://monarchinitiative.org/MONARCH_APO_0000309APO_0000245> ;
+            dc:description "{0}";
+            dc:source PMID:21715656 ;
+            OBAN:association_has_object MONARCH:OBO_APO_0000309OBO_APO_0000245 ;
             OBAN:association_has_predicate OBO:RO_0002200 ;
             OBAN:association_has_subject SGD:S000007268 .
-        }
-        """
+            
+        SGD:S000007268 rdfs:label "ATP6" ;
+        RO:0002200 MONARCH:OBO_APO_0000309OBO_APO_0000245 .
 
-        sparql_output = sgd.graph.query(sparql_query)
-        self.assertEqual(len(list(sparql_output)), 1)
+        APO:0000020 rdfs:label "classical genetics" .
+
+        PMID:21715656 a OBO:IAO_0000311 ;
+        owl:sameAs SGD_REF:S000145858 .
+
+        MONARCH:OBO_APO_0000309OBO_APO_0000245 rdfs:label "respiratory growth:decreased rate" ;
+        rdfs:subClassOf UPHENO:0001001 .
+
+        """.format(description)
+        # test exact contents of graph
+        self.assertTrue(self.test_util.test_graph_equality(
+            triples, sgd.graph))
 

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -6,6 +6,9 @@ from unittest.mock import MagicMock
 import logging
 from dipper.sources.UDP import UDP
 from rdflib import URIRef
+from dipper.utils.TestUtils import TestUtils
+from dipper.graph.RDFGraph import RDFGraph
+
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -17,6 +20,7 @@ class UDPTestCase(unittest.TestCase):
     """
 
     def setUp(self):
+        self.test_util = TestUtils()
         return
 
     def tearDown(self):
@@ -68,6 +72,12 @@ class UDPTestCase(unittest.TestCase):
         """
         functional test for _parse_patient_phenotypes()
         """
+        udp = UDP('rdf_graph', True)
+        udp.graph = RDFGraph(True)
+
+        # test that graph is empty
+        self.assertTrue(len(list(udp.graph)) == 0)
+
         mock_lines = [
             'patient_1\tHP:000001\tyes',
             'patient_1\tHP:000002\tno'
@@ -76,54 +86,71 @@ class UDPTestCase(unittest.TestCase):
         mock_data.__iter__.return_value = iter(mock_lines)
 
         mock_file = mock_open(mock=mock_data)
-        udp = UDP('rdf_graph', True)
         udp._parse_patient_phenotypes(mock_file)
-        sparql_query = """
-            SELECT ?patient
-            WHERE {
-                ?patient a foaf:Person ;
-                    rdfs:label "patient_1" ;
-                    OBO:RO_0002200 OBO:DOID_4,
-                         OBO:HP_000001 .
-            }
+        triples = """
+        :patient_1 a foaf:Person ;
+            rdfs:label "patient_1" ;
+            RO:0002200 DOID:4,
+              HP:000001 .
         """
-        sparql_output = udp.graph.query(sparql_query)
-        # Test that query passes and returns one row
-        results = list(sparql_output)
-        expected = [(URIRef(udp.graph._getNode(":patient_1")),)]
-        self.assertEqual(results, expected)
+
+        self.assertTrue(self.test_util.test_graph_equality(
+            triples, udp.graph))
 
     def test_variant_model(self):
         """
         functional test for _parse_patient_variants()
         """
-        data = ['patient_1', 'family_1', '1', 'HG19', '155230432',
-                'G', 'A', 'Maternal', 'Biallelic',
-                'Non-synonymous;DOWNSTREAM', 'CLK2',
-                '', '', '', '', '', '', '', 'Compound heterozygous',
-                'Heterozygous', '', '0.002747253', '']
+        udp = UDP('rdf_graph', True)
+        udp.graph = RDFGraph(True)
+        # test that graph is empty
+        self.assertTrue(len(list(udp.graph)) == 0)
+
+        data = ['patient_1',
+                'family_1',
+                '1',
+                'HG19',
+                '155230432',
+                'G',
+                'A',
+                'Maternal',
+                'Biallelic',
+                'Non-synonymous;DOWNSTREAM',
+                'CLK2',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                'Compound heterozygous',
+                'Heterozygous',
+                '',
+                '0.002747253',
+                '']
         test_data = "\t".join(data)
         mock_lines = [test_data]
         mock_data = MagicMock()
         mock_data.__iter__.return_value = iter(mock_lines)
 
         mock_file = mock_open(mock=mock_data)
-        udp = UDP('rdf_graph', False)
 
         udp._parse_patient_variants(mock_file)
-        sparql_query = """
-            SELECT ?patient
-            WHERE {
-                ?patient OBO:GENO_0000222 [ a OBO:GENO_0000000 ;
-                    rdfs:label "patient_1 genotype" ;
-                    OBO:GENO_0000382 [ a OBO:SO_0001059 ;
-                        rdfs:label "hg19chr1(CLK2):g.155230432G>A" ;
-                        OBO:GENO_0000418 <http://identifiers.org/hgnc/HGNC:2069> ;
-                        OBO:RO_0002162 OBO:NCBITaxon_9606 ;
-                        owl:sameAs dbSNP:rs11557757 ] ] .
-            }
+
+        triples = """
+        :patient_1 GENO:0000222 <https://monarchinitiative.org/.well-known/genid/b8a5f377fc8c95d4> .
+
+        <https://monarchinitiative.org/.well-known/genid/b641e8da0787b45e> a SO:0001059 ;
+            rdfs:label "hg19chr1(CLK2):g.155230432G>A" ;
+            GENO:0000418 HGNC:2069 ;
+            RO:0002162 NCBITaxon:9606 ;
+            owl:sameAs dbSNP:rs11557757 .
+
+        <https://monarchinitiative.org/.well-known/genid/b8a5f377fc8c95d4> a GENO:0000000 ;
+            rdfs:label "patient_1 genotype" ;
+            GENO:0000382 <https://monarchinitiative.org/.well-known/genid/b641e8da0787b45e> .
         """
-        sparql_output = udp.graph.query(sparql_query)
-        results = list(sparql_output)
-        expected = [(URIRef(udp.graph._getNode(":patient_1")),)]
-        self.assertEqual(results, expected)
+
+        self.assertTrue(self.test_util.test_graph_equality(
+            triples, udp.graph))


### PR DESCRIPTION
- [ ] fix mychem parser (removes limit)
- [ ] add tests to mychem
- [ ] refactor tests

The test refactor will remove the sparql tests in favor of testing exact sets of triples.  The new testing approach will be to:
1. Test that the graph object is empty
2. Run graph through function
3. Evaluate the set of expected triples vs the actual triples created by the function

This has the advantage over sparql in catching unexpected additional triples, where as the sparql queries would pass.  We should still use sparql for more integration style testing (see test in test_impc, test_random_data_set).