### PR TITLE
OMIM adjustments

### DIFF
--- a/dipper/graph/RDFGraph.py
+++ b/dipper/graph/RDFGraph.py
@@ -4,6 +4,7 @@ from dipper.utils.CurieUtil import CurieUtil
 from dipper import curie_map
 import re
 import logging
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,8 @@ class RDFGraph(ConjunctiveGraph, DipperGraph):
                 logger.warning(
                     "None as literal object for subj: %s and pred: %s",
                     subject_id, predicate_id)
+                # magic number 2 here is "steps up the stack"
+                logger.warning(sys._getframe(2).f_code.co_name)
         elif obj is not None and obj != '':
             self.add(
                 (self._getNode(subject_id), self._getNode(predicate_id),
@@ -61,13 +64,11 @@ class RDFGraph(ConjunctiveGraph, DipperGraph):
                 subject_id, predicate_id)
         return
 
-
     def skolemizeBlankNode(self, curie):
         stripped_id = re.sub(r'^_:|^_', '', curie, 1)
         node = BNode(stripped_id).skolemize(self.curie_util.get_base())
         node = re.sub(r'rdflib/', '', node)  # remove string added by rdflib
         return URIRef(node)
-
 
     def _getNode(self, curie):
         """
@@ -104,20 +105,6 @@ class RDFGraph(ConjunctiveGraph, DipperGraph):
             else:
                 logger.error("couldn't make URI for %s", curie)
         return node
-
-    # helper f(x) to encourage better bnode hygine
-    def makeBnode(self, bnode_identifier, rdfs_label, rdf_type, skolemize=True):
-
-        node = None
-
-        #bnode_id = blank
-        #addTriple(
-        #    self, bnode_id, "rdfs:label", rdfs_label,
-        #    object_is_literal=True, literal_type="String")
-        #addTriple(
-        #    self, bnode_id, "rdf:type", rdfs_type,
-        #    object_is_literal=False, literal_type="IRI")
-
 
     def bind_all_namespaces(self):
         for prefix in curie_map.get().keys():

--- a/dipper/models/Dataset.py
+++ b/dipper/models/Dataset.py
@@ -23,7 +23,7 @@ class Dataset:
                  license_url=None, data_rights=None, graph_type=None,
                  file_handle=None):
         if graph_type is None:
-            self.graph = RDFGraph(None, title)
+            self.graph = RDFGraph(None, identifier)  # 
         elif graph_type == 'streamed_graph':
             self.graph = StreamedGraph(True, file_handle=file_handle)
         elif graph_type == 'rdf_graph':
@@ -33,8 +33,9 @@ class Dataset:
         self.version = None
         self.date_issued = None
 
-	# The data_accesed value is later used as an object literal of properties such as dct:issued, which needs to conform xsd:dateTime format.
-        # self.date_accessed = datetime.now().strftime('%Y-%m-%d-%H-%M')
+        # The data_accesed value is later used as an literal of properties
+        # such as dct:issued, which needs to conform xsd:dateTime format.
+        # TODO ... we need to have a talk about typed literals and SPARQL
         self.date_accessed = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
 
         self.citation = set()


### PR DESCRIPTION
We might want to know more about the sudden drop in descriptions.  

Bonus cleanup of unused function in RDFGraph  

Dataset was changed to use the graph identifier as the "name" of a named graph instead of the title which only happened when the graph type was not explicitly specified.  
This was problematic because although rdflib has no problem using the title as the graph name internally,it could fail when trying to export if the title included non URL safe characters such as space or other chars which need url encoding