### PR TITLE
Add sex specific G2P qualifier from MGI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,11 @@ TEST = python3 -m unittest
 ### Tests
 ###
 
-test: UDP-test IMPC-fetch IMPC-test GWAS-test reactome-test RGD-test \
+test: MGI-test UDP-test IMPC-fetch IMPC-test GWAS-test reactome-test RGD-test \
       string-test trans-test CTD-test mychem-test
+
+MGI-test:
+	$(TEST) tests.test_mgi.EvidenceTestCase
 
 string-test:
 	$(TEST) tests/test_string.py

--- a/dipper/models/Evidence.py
+++ b/dipper/models/Evidence.py
@@ -37,7 +37,6 @@ class Evidence:
     object_properties = {
         'has_evidence': 'SEPIO:0000006',
         'has_supporting_evidence': 'SEPIO:0000007',
-        'has_evidence': 'SEPIO:0000006',
         'has_supporting_data': 'SEPIO:0000084',
         'is_evidence_for': 'SEPIO:0000031',
         'is_refuting_evidence_for': 'SEPIO:0000033',
@@ -58,7 +57,7 @@ class Evidence:
         if isinstance(graph, Graph):
             self.graph = graph
         else:
-            raise ValueError("{} is not a graph".graph)
+            raise ValueError("{} is not a graph".format(graph))
         self.model = Model(self.graph)
         self.association = association
 

--- a/dipper/models/Model.py
+++ b/dipper/models/Model.py
@@ -88,7 +88,8 @@ class Model():
         'dc:evidence': 'dc:evidence',
         'has_evidence': 'RO:0002558',
         'causally_upstream_of_or_within': 'RO:0002418',
-        'causally_influences': 'RO:0002566'
+        'causally_influences': 'RO:0002566',
+        'has_sex_specificity': ':has_sex_specificity'
     }
 
     datatype_properties = {
@@ -364,4 +365,27 @@ class Model():
         self.graph.addTriple(
             node_id, self.annotation_properties['is_anonymous'], True,
             object_is_literal=True, literal_type='xsd:boolean')
+        return
+
+    def _addSexSpecificity(self, subject_id, sex):
+        """
+        Add sex specificity to a subject (eg association node)
+
+        In our modeling we use this to add a qualifier to a triple
+        for example, this genotype to phenotype association
+        is specific to this sex (see MGI, IMPC)
+
+        This expects the client to define the ontology term
+        for sex (eg PATO)
+
+        Note this class is probably not the right place for this
+        method, but putting here until a better home is found
+        :param subject_id:
+        :param sex:
+        :return:
+        """
+        self.graph.addTriple(
+            subject_id,
+            self.object_properties['has_sex_specificity'],
+            sex)
         return

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -91,8 +91,8 @@ class MGI(PostgreSQLSource):
           'outfile': 'voc_annot_view'
         },
         {
-          'query': '../../resources/sql/mgi/voc_evidence_view.sql',
-          'outfile': 'voc_evidence_view'
+          'query': '../../resources/sql/mgi/evidence.sql',
+          'outfile': 'evidence_view'
         },
         {
           'query': '../../resources/sql/mgi/bib_acc_view.sql',
@@ -228,7 +228,7 @@ class MGI(PostgreSQLSource):
             logger.error("not configured with PG user/password.")
 
         # source-specific warnings.  will be cleared when resolved.
-        logger.warning("we are ignoring normal phenotypes for now")
+        self.global_terms = self.open_and_parse_yaml('../../translationtable/global_terms.yaml')
 
         # so that we don't have to deal with BNodes,
         # we will create hash lookups
@@ -358,7 +358,7 @@ class MGI(PostgreSQLSource):
         self._process_all_allele_mutation_view(limit)
         self._process_gxd_allele_pair_view(limit)
         self._process_voc_annot_view(limit)
-        self._process_voc_evidence_view(limit)
+        self._process_evidence_view(limit)
         self._process_mgi_note_vocevidence_view(limit)
         self._process_mrk_location_cache(limit)
         self.process_mgi_relationship_transgene_genes(limit)
@@ -1044,8 +1044,6 @@ class MGI(PostgreSQLSource):
     def _process_voc_annot_view(self, limit):
         """
         This MGI table represents associations between things.
-        We now filter this table on abnormal Genotype-Phenotype associations,
-        but may be expanded in the future.
 
         We add the internal annotation id to the idhashmap.
         It is expected that the genotypes have already been added to the idhash
@@ -1086,12 +1084,6 @@ class MGI(PostgreSQLSource):
                 # Mammalian Phenotype/Genotype are curated G2P assoc
                 if annot_type == 'Mammalian Phenotype/Genotype':
                     line_counter += 1
-
-                    # TODO add NOT annotations
-                    # skip 'normal'
-                    if qualifier == 'norm':
-                        logger.info("found normal phenotype: %s", term)
-                        continue
 
                     # We expect the label for the phenotype
                     # to be taken care of elsewhere
@@ -1164,12 +1156,19 @@ class MGI(PostgreSQLSource):
 
         return
 
-    def _process_voc_evidence_view(self, limit):
+    def _process_evidence_view(self, limit):
         """
         Here we fetch the evidence (code and publication) for the associations.
         The evidence codes are mapped from the standard GO codes to ECO.
         J numbers are added for publications.
         We will only add the evidence if the annotation is in our idhash.
+
+        We also pull in evidence qualifiers, as of June 2018 they are
+        Data Interpretation Center (eg IMPC)
+        external ref (eg UniProtKB:Q9JHI2-3 for Proteoform/Marker assoc)
+        Phenotyping Center (eg WTSI)
+        Resource Name (eg MGP)
+        MP-Sex-Specificity (eg NA, M, F)
 
         Triples:
         <annot_id> dc:evidence <evidence_id>
@@ -1182,21 +1181,27 @@ class MGI(PostgreSQLSource):
         """
 
         if self.testMode:
-            g = self.testgraph
+            graph = self.testgraph
         else:
-            g = self.graph
+            graph = self.graph
+        model = Model(graph)
         line_counter = 0
         logger.info("getting evidence and pubs for annotations")
-        raw = '/'.join((self.rawdir, 'voc_evidence_view'))
+        raw = '/'.join((self.rawdir, 'evidence_view'))
         with open(raw, 'r') as f:
             f.readline()  # read the header row; skip
             for line in f:
                 line = line.rstrip("\n")
                 line_counter += 1
 
-                (annot_evidence_key, annot_key,
-                 evidence_code, jnumid) = line.split('\t')
-
+                (annot_evidence_key,
+                 annot_key,
+                 evidence_code,
+                 jnumid,
+                 qualifier,
+                 qualifier_value,
+                 annotation_type
+                 ) = line.split('\t')
                 if self.testMode is True:
                     if int(annot_key) not in self.test_keys.get('annot'):
                         continue
@@ -1214,16 +1219,27 @@ class MGI(PostgreSQLSource):
 
                 evidence_id = self._map_evidence_id(evidence_code)
 
-                reference = Reference(g, jnumid)
+                reference = Reference(graph, jnumid)
                 reference.addRefToGraph()
 
                 # add the ECO and citation information to the annot
-                g.addTriple(assoc_id,
-                            Assoc.object_properties['has_evidence'],
-                            evidence_id)
-                g.addTriple(assoc_id,
-                            Assoc.object_properties['has_source'],
-                            jnumid)
+                model.addTriple(assoc_id,
+                                Assoc.object_properties['has_evidence'],
+                                evidence_id)
+                model.addTriple(assoc_id,
+                                Assoc.object_properties['has_source'],
+                                jnumid)
+
+                # For Mammalian Phenotype/Genotype annotation types
+                # MGI adds sex specificity qualifiers here
+                if qualifier == 'MP-Sex-Specificity'\
+                        and (qualifier_value == 'M' or qualifier_value == 'F'):
+                    sex = None
+                    if qualifier_value == 'M':
+                        sex = self.global_terms['male']
+                    elif qualifier_value == 'F':
+                        sex = self.global_terms['female']
+                    model._addSexSpecificity(assoc_id, sex)
 
                 if not self.testMode and \
                         limit is not None and line_counter > limit:

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -222,11 +222,6 @@ class MGI(PostgreSQLSource):
             'mgi', 'MGI', 'http://www.informatics.jax.org/', None,
             'http://www.informatics.jax.org/mgihome/other/copyright.shtml')
 
-        # check if config exists; if it doesn't, error out and let user know
-        if 'dbauth' not in config.get_config() and \
-                'mgi' not in config.get_config()['dbauth']:
-            logger.error("not configured with PG user/password.")
-
         # source-specific warnings.  will be cleared when resolved.
         self.global_terms = self.open_and_parse_yaml('../../translationtable/global_terms.yaml')
 
@@ -267,6 +262,11 @@ class MGI(PostgreSQLSource):
         We'll check the local table versions against the remote version
         :return:
         """
+
+        # check if config exists; if it doesn't, error out and let user know
+        if 'dbauth' not in config.get_config() and \
+                'mgi' not in config.get_config()['dbauth']:
+            logger.error("not configured with PG user/password.")
 
         # create the connection details for MGI
         cxn = config.get_config()['dbauth']['mgi']

--- a/resources/sql/mgi/evidence.sql
+++ b/resources/sql/mgi/evidence.sql
@@ -1,0 +1,16 @@
+SELECT
+  voc_evidence_view._annotevidence_key,
+  voc_evidence_view._annot_key,
+  voc_evidence_view.evidencecode,
+  voc_evidence_view.jnumid,
+  voc_term.term,
+  voc_evidence_property.value,
+  voc_annot_view.annottype
+FROM voc_evidence_view
+JOIN voc_annot_view
+  ON voc_evidence_view._annot_key = voc_annot_view._annot_key
+LEFT OUTER JOIN voc_evidence_property
+  ON voc_evidence_view._annotevidence_key = voc_evidence_property._annotevidence_key
+LEFT OUTER JOIN voc_term
+  ON voc_evidence_property._propertyterm_key = voc_term._term_key
+WHERE voc_annot_view.annottype <> 'GO/Marker'

--- a/resources/sql/mgi/voc_evidence_view.sql
+++ b/resources/sql/mgi/voc_evidence_view.sql
@@ -1,2 +1,0 @@
-SELECT _annotevidence_key, _annot_key, evidencecode, jnumid
-FROM voc_evidence_view

--- a/tests/resources/mgi/evidence_view
+++ b/tests/resources/mgi/evidence_view
@@ -1,0 +1,2 @@
+_annotevidence_key	_annot_key	evidencecode	jnumid	term	value   annottype
+7413616	6901981	EXP	J:74619	MP-Sex-Specificity	M	Mammalian Phenotype/Genotype

--- a/tests/test_mgi.py
+++ b/tests/test_mgi.py
@@ -2,12 +2,11 @@
 
 import unittest
 import logging
-# import os
-# from rdflib import Graph
-# from tests import test_general, test_source
 from tests.test_source import SourceTestCase
 from dipper.sources.MGI import MGI
-# from dipper import curie_map
+from dipper.utils.TestUtils import TestUtils
+from dipper.graph.RDFGraph import RDFGraph
+import os
 
 
 logging.basicConfig(level=logging.WARNING)
@@ -26,13 +25,43 @@ class MGITestCase(SourceTestCase):
         self.source = None
         return
 
-    # TODO add some specific tests to make sure we are
-    # hitting all parts of the code
-    # @unittest.skip('test not yet defined')
-    # def test_mgitest(self):
-    #    logger.info("An MGI-specific test")
-    #
-    #    return
+
+class EvidenceTestCase(unittest.TestCase):
+
+    def setUp(self):
+        """
+        Because _process_evidence_view uses
+        self.rawdir to find the evidence file,
+        the defaults are overriden here to
+        point to our test file
+        Note the file name must match what is in
+        that method - evidence_view
+        """
+        self.test_util = TestUtils()
+        self.mgi = MGI('rdf_graph', True)
+        self.mgi.rawdir = os.path.join(os.path.dirname(__file__), 'resources/mgi')
+        self.mgi.idhash['annot']['6901981'] = ':association'
+
+    def tearDown(self):
+        self.mgi = None
+        return
+
+    def test_sex_specificity_model(self):
+        self.mgi.graph = RDFGraph(True)  # Reset graph
+        self.mgi._process_evidence_view(limit=None)
+        logger.debug("Reference graph: %s",
+                     self.mgi.graph.serialize(format="turtle")
+                                   .decode("utf-8")
+        )
+        expected_triples = """
+        :association RO:0002558 ECO:0000006 ;
+            dc:source J:74619 ;
+            :has_sex_specificity PATO:0000384 .
+
+        J:74619 a IAO:0000310 .
+        """
+        self.assertTrue(self.test_util.test_graph_equality(
+            expected_triples, self.mgi.graph))
 
 
 if __name__ == '__main__':

--- a/translationtable/global_terms.yaml
+++ b/translationtable/global_terms.yaml
@@ -56,6 +56,7 @@
 "in vivo": "SEPIO:0000074"
 "case-control": "SEPIO:0000071"
 "phenotyping only": "SEPIO:0000186"
+"has_sex_specificty": ":has_sex_specificity"
 # provenance  unused now? (2016 06 03)
 # ENIGMA BRCA1/2 Classification Criteria (2015)	SEPIO:1000001
 # ENIGMA BRCA1/2 Classification Criteria (2015)": "SEPIO:1000001"
@@ -92,3 +93,7 @@
 "NAS": "ECO:0000303"
 "IPM": "ECO:0005612"
 "IEP": "ECO:0000270"
+
+# PATO
+"male": "PATO:0000384"
+"female": "PATO:0000383"


### PR DESCRIPTION
Updates the mgi db evidence query to include association metadata such as sex specificity - I wouldn't consider this evidence, but this is their representation.  For now I am hanging this off the association node.  See the unit test for an example input/output.

We are now getting back some other fields that may be useful, but are not added to the ingest in this PR:

Data Interpretation Center (eg IMPC)
external ref (eg UniProtKB:Q9JHI2-3 for Proteoform/Marker assoc)
Phenotyping Center (eg WTSI)
Resource Name (eg MGP)

Related ticket: https://github.com/monarch-initiative/dipper/issues/583