### PR TITLE
paste-o amd optional resolve  #610 followup

### DIFF
--- a/dipper/models/Family.py
+++ b/dipper/models/Family.py
@@ -17,7 +17,6 @@ class Family():
             self.graph = graph
         else:
             raise ValueError("{} is not a graph".graph)
-        self.model = Model(graph)
         self.globaltt = self.graph.globaltt
         self.globaltcid = self.graph.globaltcid
         self.curie_map = self.graph.curie_map

--- a/dipper/sources/GWASCatalog.py
+++ b/dipper/sources/GWASCatalog.py
@@ -380,8 +380,9 @@ SELECT ?variant_label
         # also want to add other descriptive info about
         # the variant from the context
         for c in re.split(r';', context):
-            cid = self.resolve(c.strip())
-            if cid is not None:
+            c = c.strip()
+            cid = self.resolve(c, False)
+            if cid != c:
                 model.addType(snp_id, cid)
 
         return


### PR DESCRIPTION
should check if I added the extra `model =`  line elsewhere but if so, they will show up anyway.

I am liking just setting mandatory to false when the input is more variable