### PR TITLE
rename geneontology local tt file so it is found

### DIFF
--- a/translationtable/go.yaml
+++ b/translationtable/go.yaml
@@ -1,5 +1,5 @@
 ---
-# geneontology.yaml
+# go.yaml
 
 "P": "involved in"
 "F": "enables"


### PR DESCRIPTION
I would prefer an ingest just used there lowercase ingest name as its tag
but `GeneOntology.py` uses `go` as its tag.
 so for now, changing the local mapping file to suit