### PR TITLE
UCSC fix

### DIFF
--- a/dipper/config.py
+++ b/dipper/config.py
@@ -14,9 +14,9 @@ conf = {
 }
 
 '''
-    Load the configuration file 'conf.json', if it exists.
+    Load the configuration file 'conf.yaml', if it exists.
     it isn't always required, but may be for some sources.
-    conf.json may contain sensitive info and should not live in a public repo
+    conf.yaml may contain sensitive info and should not live in a public repo
 '''
 
 if os.path.exists(os.path.join(os.path.dirname(__file__), 'conf.yaml')):

--- a/dipper/sources/UCSCBands.py
+++ b/dipper/sources/UCSCBands.py
@@ -472,7 +472,7 @@ class UCSCBands(Source):
         model = Model(graph)
         logger.info("Adding equivalent assembly identifiers")
         for sp in self.species:
-            tax_id = self.resolve(sp)
+            tax_id = self.globaltt[sp]
             txid_num = tax_id.split(':')[1]
             for key in self.files[txid_num]['assembly']:
                 ucsc_id = key


### PR DESCRIPTION
changed the order of conditions to test in resolve from 
  check  globaltt first (faster)  to check localtt first (comprehensive)
 since I used the localtt partially as a reverse map of sorts  the change in order bit me 
