### PR TITLE
moving a check further up

### DIFF
--- a/dipper/graph/Graph.py
+++ b/dipper/graph/Graph.py
@@ -1,7 +1,20 @@
 from abc import ABCMeta, abstractmethod
+import re
 
 
 class Graph(metaclass=ABCMeta):
+
+    # regular expression pattern to recognize strings which could be well formed curies
+    # I am still not subscribing to the whole unicode realm
+    # while 100% of the identifiers I actually get are 7-bit ascii
+
+    # https://www.w3.org/TR/curie/
+    # https://www.w3.org/TR/xml/
+    # https://www.w3.org/TR/rdfa-core/#s_curies
+    #
+
+    curie_regexp = re.compile(
+        r'^[a-zA-Z_][a-zA-Z_0-9-]*:[A-Za-z0-9_][A-Za-z0-9_.]*[A-Za-z0-9_]*$')
 
     @abstractmethod
     def addTriple(

--- a/dipper/graph/RDFGraph.py
+++ b/dipper/graph/RDFGraph.py
@@ -42,8 +42,15 @@ class RDFGraph(DipperGraph, ConjunctiveGraph):
         # self.bind_all_namespaces()  # too much
 
     def addTriple(
-            self, subject_id, predicate_id, obj, object_is_literal=False,
+            self, subject_id, predicate_id, obj, object_is_literal=None,
             literal_type=None):
+        # trying making infrence on type of object if none is supplied
+        if object_is_literal is None:
+            if self.curie_regexp.match(obj) or\
+                    obj.split(':')[0].lower() in ('http', 'https', 'ftp'):
+                object_is_literal = False
+            else:
+                object_is_literal = True
 
         if object_is_literal is True:
             if literal_type is not None and obj is not None:

--- a/dipper/graph/StreamedGraph.py
+++ b/dipper/graph/StreamedGraph.py
@@ -33,19 +33,25 @@ class StreamedGraph(DipperGraph):
         self.identifier = identifier
 
     def addTriple(
-            self, subject_id, predicate_id, object_id, object_is_literal=False,
+            self, subject_id, predicate_id, obj, object_is_literal=None,
             literal_type=None):
+        # trying making infrence on type of object if none is supplied
+        if object_is_literal is None:
+            if self.curie_regexp.match(obj) or\
+                    obj.split(':')[0].lower() in ('http', 'https', 'ftp'):
+                object_is_literal = False
+        else:
+            object_is_literal = True
+
         subject_iri = self._getnode(subject_id)
         predicate_iri = self._getnode(predicate_id)
         if not object_is_literal:
-            obj = self._getnode(object_id)
-        else:
-            obj = object_id
+            obj = self._getnode(obj)
 
         if literal_type is not None:
             literal_type = self._getnode(literal_type)
 
-        if object_id is not None:
+        if obj is not None:
             self.serialize(
                 subject_iri, predicate_iri, obj, object_is_literal, literal_type)
         else:

--- a/dipper/models/assoc/Association.py
+++ b/dipper/models/assoc/Association.py
@@ -1,6 +1,5 @@
 
 import logging
-import re
 from dipper.models.Model import Model
 from dipper.graph.Graph import Graph
 from dipper.utils.GraphUtils import GraphUtils
@@ -45,7 +44,6 @@ class Assoc:
         self.score = None
         self.score_type = None
         self.score_unit = None
-        self.curie_pat = re.compile(r'^.*:[A-Za-z0-9_][A-Za-z0-9_.]*[A-Za-z0-9_]*$')
 
         return
 
@@ -81,7 +79,6 @@ class Assoc:
                 'Invalid Predicate for this association <%s> <%s> <%s>',
                 self.sub, self.rel, self.obj
             )
-
         return True
 
     def add_association_to_graph(self):
@@ -114,14 +111,8 @@ class Assoc:
 
         if self.source is not None and len(self.source) > 0:
             for src in self.source:
-                object_is_literal = False
-
-                if src[:4] != 'http' and self.curie_pat.match(src) is not None:
-
-                    object_is_literal = True
-                    # TODO assume that the source is a publication? use Reference class
-                self.graph.addTriple(
-                    self.assoc_id, self.globaltt['source'], src, object_is_literal)
+                # TODO assume that the source is a publication? use Reference class
+                self.graph.addTriple(self.assoc_id, self.globaltt['source'], src)
 
         if self.provenance is not None and len(self.provenance) > 0:
             for prov in self.provenance:
@@ -131,8 +122,8 @@ class Assoc:
         if self.date is not None and len(self.date) > 0:
             for dat in self.date:
                 self.graph.addTriple(
-                    object_is_literal=True, subject_id=self.assoc_id,
-                    predicate_id=self.globaltt['created_on'], obj=dat)
+                    self.assoc_id,self.globaltt['created_on'], dat,
+                    object_is_literal=True)
 
         if self.score is not None:
             self.graph.addTriple(

--- a/dipper/models/assoc/D2PAssoc.py
+++ b/dipper/models/assoc/D2PAssoc.py
@@ -64,16 +64,13 @@ class D2PAssoc(Assoc):
         # if rel == self.globaltt[['has disposition']:
 
         Assoc.add_association_to_graph(self)
-
-        object_is_literal = True
+        # anticipating trouble with onsets ranges that look like curies
+        if self.onset is not None and self.onset != '':
+            self.graph.addTriple(self.assoc_id, self.globaltt['onset'], self.onset)
 
         if self.frequency is not None and self.frequency != '':
             self.graph.addTriple(
-                self.assoc_id, self.globaltt['frequency'], self.frequency,
-                object_is_literal)
-        if self.onset is not None and self.onset != '':
-            self.graph.addTriple(
-                self.assoc_id, self.globaltt['onset'], self.onset, object_is_literal)
+                self.assoc_id, self.globaltt['frequency'], self.frequency)
 
         return
 


### PR DESCRIPTION
Trying to reduce the occurrence of rdf object as a literal when it should be a curie/IRI

previously rdf objects defaulted to literals, now if undeclared, 
an effort is made to determine if the object could be a literal or not