### PR TITLE
OMIM: adopt Phenotypic Series curie 

### DIFF
--- a/dipper/sources/GeneOntology.py
+++ b/dipper/sources/GeneOntology.py
@@ -17,7 +17,7 @@ from dipper.models.Genotype import Genotype
 from dipper.models.Reference import Reference
 from dipper.models.Model import Model
 from dipper.utils.GraphUtils import GraphUtils
-from dipper import config
+
 
 LOG = logging.getLogger(__name__)
 GOGA = 'http://geneontology.org/gene-associations'

--- a/scripts/ntriple2dot.awk
+++ b/scripts/ntriple2dot.awk
@@ -18,7 +18,7 @@
 
 
 function usage(){
-	print "usage: ntriple2dot.awk curie_map.yaml rdf.nt > rdf.dot"
+	print "usage: ntriple2dot.awk prefix_baseurl.yaml rdf.nt > dot.gv"
 }
 
 ##########################################################
@@ -93,7 +93,7 @@ BEGIN{
 	# exceptions
 	prefix["BNODE"]="BNODE"  # is a fixed point
 	prefix["https://monarchinitiative.org/.well-known/genid"]="BNODE"
-	prefid["https_archive_monarchinitiative_org_"]="MonarchArchive
+	prefid["https_archive_monarchinitiative_org_"]="MonarchArchive"
 	############################################################
 	# Often re-visit whether these exceptions are still necessary
 	# they may have been moved into the curie prefix mapping file
@@ -102,7 +102,7 @@ BEGIN{
 
 	# in mgi
 	prefix["https://www.mousephenotype.org"]="IMPC"
-    # in IMPC (not httpS)
+	# in IMPC (not httpS)
 	prefix["http://www.mousephenotype.org"]="IMPC"
 	# note in curie_map IMPC is:
 	# http://www.mousephenotype.org/data/genes/


### PR DESCRIPTION
OMIM was built using the same curies for omim identifiers and Phenotypic Series identifiers
this PR corrects that.  closes #701

Movement towards codifying the expected incoming headers 
(as has happened across many ingests already)
is also captures in a pre functional state.
These column headers are used to detect/warn of incoming churn and  to 
mitigate code changes for simple column rearrangement/add/drop
(unless a dropped  column is explicitly required) 
and to preserve the source’s intent  for the data our code is acting on. 

