### PR TITLE
NCBI gene  taxon assignment fix

### DIFF
--- a/dipper/curie_map.yaml
+++ b/dipper/curie_map.yaml
@@ -174,6 +174,7 @@
 # genes (and RNAs and transcripts)
 'BIOGRID': 'http://thebiogrid.org/'                                             # Biological General Repository for Interaction Datasets
 'CCDS': 'http://www.ncbi.nlm.nih.gov/CCDS/CcdsBrowse.cgi?REQUEST=CCDS&DATA='    # Consensus CDS (CoDing Sequence)
+'CGNC': 'http://birdgenenames.org/cgnc/GeneReport?id='                          # Chicken Gene Nomenclature Consortium
 'dictyBase': 'http://dictybase.org/gene/'                                       # Dictyostelium discoideum database (social amoebae)
 'EcoGene': 'http://ecogene.org/gene/'                                           # Escherichia coli K-1
 'ENSEMBL': 'http://ensembl.org/id/'                                             # joint EMBL, EBI, Sanger Institute central resource

--- a/dipper/sources/NCBIGene.py
+++ b/dipper/sources/NCBIGene.py
@@ -237,7 +237,7 @@ class NCBIGene(Source):
                 tax_num = row[col.index('tax_id')]
                 if not self.test_mode and tax_num not in self.tax_ids:
                     continue
-
+                tax_id = ':'.join(('NCBITaxon:', tax_num))
                 gene_id = ':'.join(('NCBIGene', gene_num))
                 gtype = row[col.index('type_of_gene')].strip()
                 gene_type_id = self.resolve(gtype)

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -248,8 +248,18 @@ class Source:
     def hash_id(wordage):  # same as graph/GraphUtils.digest_id(wordage)
         """
         prepend 'b' to avoid leading with digit
-        truncate to 64bit sized word
-        return sha1 hash of string
+        truncate to a 20 char sized word with a leading 'b'
+        return truncated sha1 hash of string.
+
+        by the birthday paradox;
+            expect 50% chance of collision after 69 billion invocations
+            however these are only hoped to be unique within a single file
+
+        Consider reducing to 17 hex chars to fit in a 64 bit word
+        16 discounting a leading constant
+        gives a 50% chance of collision at about 4.3b billion unique input strings
+        (currently _many_ orders of magnitude below that)
+
         :param long_string: str string to be hashed
         :return: str hash of id
         """

--- a/tests/test_animalqtl.py
+++ b/tests/test_animalqtl.py
@@ -6,15 +6,15 @@ from dipper.sources.AnimalQTLdb import AnimalQTLdb
 from tests.test_source import SourceTestCase
 
 logging.basicConfig(level=logging.WARNING)
-logger = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 class AnimalQTLdbTestCase(SourceTestCase):
 
     def setUp(self):
         self.source = AnimalQTLdb('rdf_graph', True)
-        self.source.gene_ids = self._get_conf()['test_ids']['gene']
-        self.source.disease_ids = self._get_conf()['test_ids']['disease']
+        self.source.gene_ids = self.source.all_test_ids['gene']
+        self.source.disease_ids = self.source.all_test_ids['disease']
         self.source.settestonly(True)
         self._setDirToSource()
         return

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -5,7 +5,6 @@ import logging
 import os
 import yaml
 from tests import test_general
-# from tests import test_dataset
 from dipper.utils.GraphUtils import GraphUtils
 
 logging.basicConfig(level=logging.WARNING)


### PR DESCRIPTION

increasing distinctions between when a variable is a bare identifier v.s. when it is qualified 
allowed an error when the current curie fell out of sync with the current bare identifier.

closes #704 