### PR TITLE
fixed deprecated call to yaml.load without Loader argument

### DIFF
--- a/dipper/curie_map.py
+++ b/dipper/curie_map.py
@@ -19,7 +19,7 @@ curie_map = None
 if os.path.exists(os.path.join(os.path.dirname(__file__), 'curie_map.yaml')):
     with open(os.path.join(os.path.dirname(__file__), 'curie_map.yaml')) \
             as yaml_file:
-        curie_map = yaml.load(yaml_file)
+        curie_map = yaml.load(yaml_file, Loader=yaml.FullLoader)
         logger.debug("Finished loading curie maps: %s", curie_map)
 else:
     logger.debug(


### PR DESCRIPTION
see here:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
