### PR TITLE
Update GO gene annotation URLs

### DIFF
--- a/dipper/sources/GeneOntology.py
+++ b/dipper/sources/GeneOntology.py
@@ -20,7 +20,7 @@ from dipper.utils.GraphUtils import GraphUtils
 
 
 LOG = logging.getLogger(__name__)
-GOGA = 'http://current.geneontology.org/annotations/' # get gene annotation from current.geneontology.com, which is the last official release (but not the bleeding edge)
+GOGA = 'http://current.geneontology.org/annotations' # get gene annotation from current.geneontology.com, which is the last official release (but not the bleeding edge)
 FTPEBI = 'ftp://ftp.uniprot.org/pub/databases/'     # best for North America
 UPCRKB = 'uniprot/current_release/knowledgebase/'
 
@@ -46,8 +46,8 @@ class GeneOntology(Source):
 
     files = {
         '9615': {
-            'file': 'gene_association.goa_dog.gz',
-            'url': GOGA + '/gene_association.goa_dog.gz'},
+            'file': 'goa_dog.gaf.gz',
+            'url': GOGA + '/goa_dog.gaf.gz'},
         '7227': {
             'file': 'fb.gaf.gz',
             'url': GOGA + '/fb.gaf.gz'},
@@ -80,7 +80,7 @@ class GeneOntology(Source):
             'url': GOGA + '/sgd.gaf.gz'},
         '4896': {
             'file': 'pombase.gaf.gz',
-            'url': GOGA + '/gene_association.pombase.gz'},
+            'url': GOGA + '/pombase.gaf.gz'},
         # consider this after most others - should this be part of GO?
         # 'multispecies': {
         #   'file': 'gene_association.goa_uniprot.gz',

--- a/dipper/sources/GeneOntology.py
+++ b/dipper/sources/GeneOntology.py
@@ -20,7 +20,7 @@ from dipper.utils.GraphUtils import GraphUtils
 
 
 LOG = logging.getLogger(__name__)
-GOGA = 'http://geneontology.org/gene-associations'
+GOGA = 'http://current.geneontology.org/annotations/' # get gene annotation from current.geneontology.com, which is the last official release (but not the bleeding edge)
 FTPEBI = 'ftp://ftp.uniprot.org/pub/databases/'     # best for North America
 UPCRKB = 'uniprot/current_release/knowledgebase/'
 
@@ -47,39 +47,39 @@ class GeneOntology(Source):
     files = {
         '9615': {
             'file': 'gene_association.goa_dog.gz',
-            'url': GOGA + '/goa_dog.gaf.gz'},
+            'url': GOGA + '/gene_association.goa_dog.gz'},
         '7227': {
-            'file': 'gene_association.fb.gz',
-            'url': GOGA + '/gene_association.fb.gz'},
+            'file': 'fb.gaf.gz',
+            'url': GOGA + '/fb.gaf.gz'},
         '7955': {
-            'file': 'gene_association.zfin.gz',
-            'url': GOGA + '/gene_association.zfin.gz'},
+            'file': 'zfin.gaf.gz',
+            'url': GOGA + '/zfin.gaf.gz'},
         '10090': {
-            'file': 'gene_association.mgi.gz',
-            'url': GOGA + '/gene_association.mgi.gz'},
+            'file': 'mgi.gaf.gz',
+            'url': GOGA + '/mgi.gaf.gz'},
         '10116': {
-            'file': 'gene_association.rgd.gz',
-            'url': GOGA + '/gene_association.rgd.gz'},
+            'file': 'rgd.gaf.gz',
+            'url': GOGA + '/rgd.gaf.gz'},
         '6239': {
-            'file': 'gene_association.wb.gz',
-            'url': GOGA + '/gene_association.wb.gz'},
+            'file': 'wb.gaf.gz',
+            'url': GOGA + '/wb.gaf.gz'},
         '9823': {
-            'file': 'gene_association.goa_ref_pig.gz',
+            'file': 'goa_pig.gaf.gz',
             'url': GOGA + '/goa_pig.gaf.gz'},
         '9031': {
-            'file': 'gene_association.goa_ref_chicken.gz',
+            'file': 'goa_chicken.gaf.gz',
             'url': GOGA + '/goa_chicken.gaf.gz'},
         '9606': {
-            'file': 'gene_association.goa_ref_human.gz',
+            'file': 'goa_human.gaf.gz',
             'url': GOGA + '/goa_human.gaf.gz'},
         '9913': {
             'file': 'goa_cow.gaf.gz',
             'url': GOGA + '/goa_cow.gaf.gz'},
         '559292': {
-            'file': 'gene_association.sgd.gz',
-            'url': GOGA + '/gene_association.sgd.gz'},
+            'file': 'sgd.gaf.gz',
+            'url': GOGA + '/sgd.gaf.gz'},
         '4896': {
-            'file': 'gene_association.pombase.gz',
+            'file': 'pombase.gaf.gz',
             'url': GOGA + '/gene_association.pombase.gz'},
         # consider this after most others - should this be part of GO?
         # 'multispecies': {
@@ -87,7 +87,7 @@ class GeneOntology(Source):
         #   'url': FTPEBI + 'GO/goa/UNIPROT/gene_association.goa_uniprot.gz'},
         'go-references': {
             'file': 'GO.references',
-            'url': 'http://www.geneontology.org/doc/GO.references'},
+            'url': 'http://www.geneontology.org/doc/GO.references'}, # Quoth the header of this file: "This file is DEPRECATED. Please see go-refs.json relative to this location" (http://current.geneontology.org/metadata/go-refs.json)
         'id-map': {  # 5GB mapping file takes 6 hours to DL ... maps UniProt to Ensembl
             'file': 'idmapping_selected.tab.gz',
             'url':  FTPEBI + UPCRKB + 'idmapping/idmapping_selected.tab.gz'


### PR DESCRIPTION
Updated some GO annotation files. Should fix some errors in the current Dipper ingest. 

I've changed the domain to pull GO gene annotations from http://current.geneontology.org/annotations/ per Seth's suggestion. This current subdomain contains the "release" version of these files. These should be fairly stable. 