### PR TITLE
HGNC @  and common test ids

### DIFF
--- a/dipper/sources/HGNC.py
+++ b/dipper/sources/HGNC.py
@@ -207,10 +207,11 @@ class HGNC(OMIMSource):
 
                 if locus_type == 'withdrawn':
                     model.addDeprecatedClass(hgnc_id)
-                elif locus_type == 'region':  # results in '@' appended to gene symbol
+                elif symbol[-1] == '@':  # 10)  region (HOX), RNA cluster, gene (PCDH)
                     continue
+
                 else:
-                    gene_type_id = self.resolve(locus_type, False)  # withdrawn -> None?
+                    gene_type_id = self.resolve(locus_type, mandatory=False)
                     if gene_type_id != locus_type:
                         model.addClassToGraph(hgnc_id, symbol, gene_type_id, name)
                     model.makeLeader(hgnc_id)

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -781,8 +781,8 @@ class Source:
         to a global mapping only; if need be.
 
         :param word:  the srting to find as a key in translation tables
-        :param  mandatory: boolean to cauae failure when no key exists
-
+        :param mandatory: boolean to cauae failure when no key exists
+        :param default: string to return if nothing is found (& not manandatory)
         :return
             value from global translation table,
             or value from local translation table,

--- a/tests/test_hgnc.py
+++ b/tests/test_hgnc.py
@@ -13,7 +13,7 @@ class HGNCTestCase(SourceTestCase):
 
     def setUp(self):
         self.source = HGNC('rdf_graph', True)
-        self.source.test_ids = self._get_conf()['test_ids']['gene']
+        self.source.test_ids = self._get_testids()['gene']
         self.source.settestonly(True)
         self._setDirToSource()
         return

--- a/tests/test_hpoa.py
+++ b/tests/test_hpoa.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class HPOATestCase(SourceTestCase):
     def setUp(self):
         self.source = HPOAnnotations('rdf_graph', True)
-        #self.source.test_ids = self._get_conf()['test_ids']['disease']
+        self.source.test_ids = self._get_testids['disease']
         self.source.settestonly(True)
         self._setDirToSource()
         return

--- a/tests/test_kegg.py
+++ b/tests/test_kegg.py
@@ -17,7 +17,7 @@ class KEGGTestCase(SourceTestCase):
 
     def setUp(self):
         self.source = KEGG('rdf_graph', True)
-        self.source.disease_ids = self._get_conf()['test_ids']['disease']
+        self.source.disease_ids = self._get_testids['disease']
         self.source.settestonly(True)
         self._setDirToSource()
         return

--- a/tests/test_oma.py
+++ b/tests/test_oma.py
@@ -13,7 +13,7 @@ class OMATestCase(SourceTestCase):
 
     def setUp(self):
         self.source = OMA('rdf_graph', True)
-        self.source.test_ids = self._get_conf()['test_ids']['protein']
+        self.source.test_ids = self._get_testids['protein']
         self.source.settestonly(True)
         self._setDirToSource()
         return

--- a/tests/test_panther.py
+++ b/tests/test_panther.py
@@ -13,7 +13,7 @@ class PantherTestCase(SourceTestCase):
 
     def setUp(self):
         self.source = Panther('rdf_graph', True)
-        self.source.test_ids = self._get_conf()['test_ids']['protein']
+        self.source.test_ids = self._get_testids['protein']
         self.source.settestonly(True)
         self._setDirToSource()
         return

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -81,15 +81,15 @@ class SourceTestCase(unittest.TestCase):
             logging.info("Resetting the rawdir to %s", p)
         return
 
-    # no such 'test_ids.json' file exists
-    # def _get_conf(self):
-    #    if os.path.exists(
-    #            os.path.join(os.path.dirname(__file__), 'test_ids.json')):
-    #        with open(
-    #            os.path.join(
-    #                os.path.dirname(__file__), 'test_ids.json')) as json_file:
-    #             conf = json.load(json_file)
-    #    return conf
+    # no such 'test_ids.json' file exists  ->  became yaml
+    def _get_testid(self):
+        tst_id_pth = '/'.join((os.path.dirname(__file__), '../resources/test_ids.yaml'))
+
+        print(tst_id_pth)
+        if os.path.exists(tst_id_pth):
+            with open(tst_id_pth) as yaml_file:
+                conf = yaml.safe_load(yaml_file)
+        return conf
 
     """
     Commenting out as most of our sources do not have licenses


### PR DESCRIPTION
HGNC has several types which get a trailing '@' appended to the gene symbol.
the majority of these are  not propagates because they are of type "withdrawn" 
of the remaining 10, 6 are not propagated because they were of type 'region'

from the comments, the remaining four most likely were expected to be excluded as well
for having the '@' but have other types  ... RNA cluster which were not filtered.

I have changed the test from the type being `region` to if there is a trailing `@` on the symbol
which excludes the remaining few.
(note the items in the clusters/regions have their own HGNC ids that we keep)

-------------------
When centralizing the common test ids and converting the format to YAML 
some tests fell by the wayside and are now back to running.
 