### PR TITLE
Remove testsuite from zfin

### DIFF
--- a/dipper/sources/ZFIN.py
+++ b/dipper/sources/ZFIN.py
@@ -2722,13 +2722,6 @@ class ZFIN(Source):
         targeted_gene_id = '_:' + targeted_gene_id
         return targeted_gene_id
 
-    def getTestSuite(self):
-        import unittest
-        from tests.test_zfin import ZFINTestCase
-
-        test_suite = unittest.TestLoader().loadTestsFromTestCase(ZFINTestCase)
-
-        return test_suite
 
     # #### SOME OLD (COBLO?) CODE #####
 


### PR DESCRIPTION
Removes testsuite code that resulted in a handful of source filepaths being overwritten in dipper-etl.py.  Our qc caught this via:

Genotype Phenotype
Danio rerio | 653 (-101276)

Variant Phenotype
Danio rerio | 8132 (-83923)

Variant Genotype
Danio rerio | 4 (-153358)










