### PR TITLE
Comment out gene to disease parser for ctd and kegg

### DIFF
--- a/dipper/sources/CTD.py
+++ b/dipper/sources/CTD.py
@@ -61,14 +61,14 @@ class CTD(Source):
             'file': 'CTD_chemicals_diseases.tsv.gz',
             'url': 'http://ctdbase.org/reports/CTD_chemicals_diseases.tsv.gz'
         },
-        'gene_pathway': {
-            'file': 'CTD_genes_pathways.tsv.gz',
-            'url': 'http://ctdbase.org/reports/CTD_genes_pathways.tsv.gz'
-        },
-        'gene_disease': {
-            'file': 'CTD_genes_diseases.tsv.gz',
-            'url': 'http://ctdbase.org/reports/CTD_genes_diseases.tsv.gz'
-        }
+        #'gene_pathway': {
+        #    'file': 'CTD_genes_pathways.tsv.gz',
+        #    'url': 'http://ctdbase.org/reports/CTD_genes_pathways.tsv.gz'
+        #},
+        #'gene_disease': {
+        #    'file': 'CTD_genes_diseases.tsv.gz',
+        #    'url': 'http://ctdbase.org/reports/CTD_genes_diseases.tsv.gz'
+        #}
     }
     static_files = {
         'publications': {'file': 'CTD_curated_references.tsv'}
@@ -149,8 +149,10 @@ class CTD(Source):
 
         self._parse_ctd_file(
             limit, self.files['chemical_disease_interactions']['file'])
-        self._parse_ctd_file(limit, self.files['gene_pathway']['file'])
-        self._parse_ctd_file(limit, self.files['gene_disease']['file'])
+
+        # Per @cmungall's request, removing gene disease associations
+        #self._parse_ctd_file(limit, self.files['gene_pathway']['file'])
+        #self._parse_ctd_file(limit, self.files['gene_disease']['file'])
         self._parse_curated_chem_disease(limit)
 
         LOG.info("Done parsing files.")

--- a/dipper/sources/KEGG.py
+++ b/dipper/sources/KEGG.py
@@ -145,18 +145,19 @@ class KEGG(OMIMSource):
         if self.test_only:
             self.test_mode = True
 
-        self._process_diseases(limit)
-        self._process_genes(limit)
-        self._process_genes_kegg2ncbi(limit)
-        self._process_omim2gene(limit)
-        self._process_omim2disease(limit)
-        self._process_kegg_disease2gene(limit)
         self._process_pathways(limit)
+        self._process_genes_kegg2ncbi(limit)
         self._process_pathway_pubmed(limit)
         self._process_pathway_disease(limit)
-        self._process_pathway_ko(limit)
 
-        self._process_ortholog_classes(limit)
+        #self._process_diseases(limit)
+        #self._process_genes(limit)
+        #self._process_omim2gene(limit)
+        #self._process_omim2disease(limit)
+        #self._process_kegg_disease2gene(limit)
+        #self._process_pathway_ko(limit)
+        #self._process_ortholog_classes(limit)
+
         # TODO add in when refactoring for #141
         # for f in ['hsa_orthologs', 'mmu_orthologs', 'rno_orthologs',
         #           'dme_orthologs','dre_orthologs','cel_orthologs']:

--- a/dipper/sources/KEGG.py
+++ b/dipper/sources/KEGG.py
@@ -150,13 +150,13 @@ class KEGG(OMIMSource):
         self._process_pathway_pubmed(limit)
         self._process_pathway_disease(limit)
 
-        #self._process_diseases(limit)
-        #self._process_genes(limit)
-        #self._process_omim2gene(limit)
-        #self._process_omim2disease(limit)
+        self._process_diseases(limit)
+        self._process_genes(limit)
+        self._process_omim2gene(limit)
+        self._process_omim2disease(limit)
         #self._process_kegg_disease2gene(limit)
-        #self._process_pathway_ko(limit)
-        #self._process_ortholog_classes(limit)
+        self._process_pathway_ko(limit)
+        self._process_ortholog_classes(limit)
 
         # TODO add in when refactoring for #141
         # for f in ['hsa_orthologs', 'mmu_orthologs', 'rno_orthologs',


### PR DESCRIPTION
Per @cmungall 's request - removing the gene to disease parsers from kegg and CTD.  Closes #814 