### PR TITLE
Make clinvar variants and dbsnp ids xrefs instead of eqs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -306,7 +306,7 @@ pipeline {
 
                             export PYTHONPATH=.:$PYTHONPATH
                             venv/bin/python ./dipper/sources/ClinVarXML_alpha.py
-                            scp ./out/clinvarxml_alpha.nt monarch@$MONARCH_DATA_FS:${DATA_DEST}/clinvar.nt
+                            scp ./out/clinvar.nt monarch@$MONARCH_DATA_FS:${DATA_DEST}
                         '''
                     }
                 }

--- a/dipper/models/ClinVarRecord.py
+++ b/dipper/models/ClinVarRecord.py
@@ -120,6 +120,7 @@ class ClinVarRecord:
     created: Created date
     updated: Updated date
     genovar: the variant or genotype associated with the condition(s)
+    significance: clinical significance (eg benign, pathogenic)
     condition: The condition(s) for which this allele set was interpreted, with
                links to databases with defining information about that condition.
     """
@@ -129,10 +130,13 @@ class ClinVarRecord:
                  created: str,
                  updated: str,
                  genovar: Genovar,
+                 significance: str,
                  conditions: Optional[List[Condition]] = None):
         self.id = id
         self.accession = accession
         self.created = created
         self.updated = updated
         self.genovar = genovar
+        self.significance = significance
         self.conditions = conditions if conditions is not None else []
+

--- a/dipper/sources/ClinVarXML_alpha.py
+++ b/dipper/sources/ClinVarXML_alpha.py
@@ -616,7 +616,7 @@ def parse():
 
     # Seed releasetriple to avoid union with the empty set
     # <MonarchData: + args.output> <a> <owl:Ontology>
-    releasetriple.add(make_spo('MonarchData:' + 'clinvar.nt', 'a', 'owl:Ontology'))
+    releasetriple.add(make_spo('MonarchData:' + args.output, 'a', 'owl:Ontology'))
 
     rjct_cnt = tot_cnt = 0
     #######################################################

--- a/tests/resources/clinvar/dot/RCV000087646.dot
+++ b/tests/resources/clinvar/dot/RCV000087646.dot
@@ -1,73 +1,73 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
 	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node7 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node9 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node0 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node8 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node7 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node0 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
-	node4 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node5 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node13 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node8 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node5 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node6 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node7 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasdbxref</font> > ] ;
-	node0 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
-	node6 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node6 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node6 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node0 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
-	node4 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node5 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/101408 node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/clinvar/variation/101408</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/101408' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/101408</font></td></tr></table> > ] 
-# https://monarchinitiative.org/mosaic_genotype node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>mosaic_genotype</B></td></tr><tr><td href='https://monarchinitiative.org/mosaic_genotype' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/mosaic_genotype</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b344a747065c549662e8 node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b344a747065c549662e8' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b344a747065c549662e8</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000067 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/107155 node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_000090.3(COL3A1):c.[=/3440_3466del27] (p.Pro1147_Gly1155del)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/107155' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/107155</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3p1:p.Pro1147_Gly1155del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3t1:c.[=/3440_3466del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.3440-3466del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.[=/3440_3466del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_000081.1:p.Pro1147_Gly1155del&quot;</td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/107154 node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_000090.3(COL3A1):c.[=/3426_3452del27] (p.Gly1143_Asp1151del)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/107154' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/107154</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3p1:p.Gly1143_Asp1151del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3t1:c.[=/3426_3452del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.3426-3452del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.[=/3426_3452del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_000081.1:p.Gly1143_Asp1151del&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b409eb231ce1985a1a4d node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b409eb231ce1985a1a4d</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b409eb231ce1985a1a4d' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b409eb231ce1985a1a4d</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bb77ce61eda1e1160cfd node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b409eb231ce1985a1a4d_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bb77ce61eda1e1160cfd' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bb77ce61eda1e1160cfd</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000120538.1&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bcffea4366ef7f890f2a node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b409eb231ce1985a1a4d_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bcffea4366ef7f890f2a' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bcffea4366ef7f890f2a</font></td></tr></table> > ] 
-# https://data.monarchinitiative.org/ttl/RCV000087646.nt node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000087646.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000087646.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000087646.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# http://omim.org/entry/130050 node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Ehlers-Danlos syndrome, type 4&quot;</B></td></tr><tr><td href='http://omim.org/entry/130050' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/130050</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058 node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Collagen Diagnostic Laboratory,University of Washington&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/1281 node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/1281</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/1281' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/1281</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000087646 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000087646</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000087646' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000087646</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000840 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
-# http://purl.org/oban/association node20
-node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0000159 node21
-node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0000159</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0000159' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0000159</font></td></tr></table> > ] 
+	node5 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node5 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node6 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
+	node3 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node4 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node4 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node6 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node2 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node6 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
+	node0 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node16 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node6 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node0 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node5 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node5 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node6 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
+	node4 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node15 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node15 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node5 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+# https://monarchinitiative.org/.well-known/genid/bb77ce61eda1e1160cfd node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_212295&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bb77ce61eda1e1160cfd' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bb77ce61eda1e1160cfd</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000120538.1&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/107155 node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_000090.3(COL3A1):c.[=/3440_3466del27] (p.Pro1147_Gly1155del)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/107155' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/107155</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3p1:p.Pro1147_Gly1155del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3t1:c.[=/3440_3466del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.3440-3466del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.[=/3440_3466del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_000081.1:p.Pro1147_Gly1155del&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b344a747065c549662e8 node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b344a747065c549662e8' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b344a747065c549662e8</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/107154 node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_000090.3(COL3A1):c.[=/3426_3452del27] (p.Gly1143_Asp1151del)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/107154' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/107154</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3p1:p.Gly1143_Asp1151del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3t1:c.[=/3426_3452del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.3426-3452del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.[=/3426_3452del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_000081.1:p.Gly1143_Asp1151del&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b409eb231ce1985a1a4d node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b409eb231ce1985a1a4d</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b409eb231ce1985a1a4d' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b409eb231ce1985a1a4d</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/101408 node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/clinvar/variation/101408</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/101408' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/101408</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000067 node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/1281 node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/1281</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/1281' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/1281</font></td></tr></table> > ] 
+# https://data.monarchinitiative.org/ttl/RCV000087646.nt node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000087646.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000087646.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000087646.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/mosaic_genotype node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>mosaic_genotype</B></td></tr><tr><td href='https://monarchinitiative.org/mosaic_genotype' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/mosaic_genotype</font></td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000087646 node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000087646</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000087646' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000087646</font></td></tr></table> > ] 
+# http://omim.org/entry/130050 node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Ehlers-Danlos syndrome, type 4&quot;</B></td></tr><tr><td href='http://omim.org/entry/130050' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/130050</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bcffea4366ef7f890f2a node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b409eb231ce1985a1a4d_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bcffea4366ef7f890f2a' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bcffea4366ef7f890f2a</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Collagen Diagnostic Laboratory,University of Washington&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# http://purl.org/oban/association node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0000159 node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0000159</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0000159' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0000159</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node20
+node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000840 node21
+node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/dot/RCV000087646.dot
+++ b/tests/resources/clinvar/dot/RCV000087646.dot
@@ -1,71 +1,71 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node5 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node5 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node6 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
-	node3 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node4 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node4 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node6 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node10 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node5 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node2 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node6 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
-	node0 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node16 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node0 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node5 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node5 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node5 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node6 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
-	node4 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node6 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node8 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node10 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node2 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node0 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node8 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node8 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node2 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node6 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
+	node2 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node17 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node13 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node6 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
+	node6 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
+	node6 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node0 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node15 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node10 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
 	node15 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node15 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node5 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-# https://monarchinitiative.org/.well-known/genid/bb77ce61eda1e1160cfd node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_212295&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bb77ce61eda1e1160cfd' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bb77ce61eda1e1160cfd</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000120538.1&quot;</td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/107155 node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_000090.3(COL3A1):c.[=/3440_3466del27] (p.Pro1147_Gly1155del)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/107155' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/107155</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3p1:p.Pro1147_Gly1155del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3t1:c.[=/3440_3466del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.3440-3466del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.[=/3440_3466del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_000081.1:p.Pro1147_Gly1155del&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b344a747065c549662e8 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b344a747065c549662e8' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b344a747065c549662e8</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/107154 node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_000090.3(COL3A1):c.[=/3426_3452del27] (p.Gly1143_Asp1151del)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/107154' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/107154</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3p1:p.Gly1143_Asp1151del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3t1:c.[=/3426_3452del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.3426-3452del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.[=/3426_3452del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_000081.1:p.Gly1143_Asp1151del&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b409eb231ce1985a1a4d node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b409eb231ce1985a1a4d</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b409eb231ce1985a1a4d' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b409eb231ce1985a1a4d</font></td></tr></table> > ] 
+	node2 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node2 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/107154 node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_000090.3(COL3A1):c.[=/3426_3452del27] (p.Gly1143_Asp1151del)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/107154' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/107154</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3p1:p.Gly1143_Asp1151del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3t1:c.[=/3426_3452del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.3426-3452del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.[=/3426_3452del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_000081.1:p.Gly1143_Asp1151del&quot;</td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/1281 node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/1281</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/1281' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/1281</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b409eb231ce1985a1a4d node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b409eb231ce1985a1a4d</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b409eb231ce1985a1a4d' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b409eb231ce1985a1a4d</font></td></tr></table> > ] 
+# http://purl.org/oban/association node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058 node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Collagen Diagnostic Laboratory,University of Washington&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
 # http://www.ncbi.nlm.nih.gov/clinvar/variation/101408 node6
 node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/clinvar/variation/101408</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/101408' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/101408</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000067 node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/1281 node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/1281</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/1281' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/1281</font></td></tr></table> > ] 
-# https://data.monarchinitiative.org/ttl/RCV000087646.nt node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000087646.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000087646.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000087646.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/mosaic_genotype node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>mosaic_genotype</B></td></tr><tr><td href='https://monarchinitiative.org/mosaic_genotype' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/mosaic_genotype</font></td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000087646 node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000087646</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000087646' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000087646</font></td></tr></table> > ] 
-# http://omim.org/entry/130050 node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Ehlers-Danlos syndrome, type 4&quot;</B></td></tr><tr><td href='http://omim.org/entry/130050' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/130050</font></td></tr></table> > ] 
+# https://monarchinitiative.org/mosaic_genotype node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>mosaic_genotype</B></td></tr><tr><td href='https://monarchinitiative.org/mosaic_genotype' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/mosaic_genotype</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/107155 node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_000090.3(COL3A1):c.[=/3440_3466del27] (p.Pro1147_Gly1155del)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/107155' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/107155</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3p1:p.Pro1147_Gly1155del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_3t1:c.[=/3440_3466del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.3440-3466del&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000090.3:c.[=/3440_3466del27]&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_000081.1:p.Pro1147_Gly1155del&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bb77ce61eda1e1160cfd node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b409eb231ce1985a1a4d_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bb77ce61eda1e1160cfd' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bb77ce61eda1e1160cfd</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000120538.1&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# http://omim.org/entry/130050 node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Ehlers-Danlos syndrome, type 4&quot;</B></td></tr><tr><td href='http://omim.org/entry/130050' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/130050</font></td></tr></table> > ] 
+# https://data.monarchinitiative.org/ttl/RCV000087646.nt node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000087646.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000087646.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000087646.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0000159 node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0000159</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0000159' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0000159</font></td></tr></table> > ] 
 # https://monarchinitiative.org/.well-known/genid/bcffea4366ef7f890f2a node15
 node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b409eb231ce1985a1a4d_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bcffea4366ef7f890f2a' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bcffea4366ef7f890f2a</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Collagen Diagnostic Laboratory,University of Washington&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
-# http://purl.org/oban/association node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0000159 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0000159</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0000159' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0000159</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000087646 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000087646</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000087646' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000087646</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b344a747065c549662e8 node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:bcffea4366ef7f890f2aSEPIO:0000067&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b344a747065c549662e8' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b344a747065c549662e8</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000067 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
 # http://purl.obolibrary.org/obo/ECO_0000000 node20
 node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
 # http://purl.obolibrary.org/obo/GENO_0000840 node21

--- a/tests/resources/clinvar/dot/RCV000112698.dot
+++ b/tests/resources/clinvar/dot/RCV000112698.dot
@@ -1,129 +1,129 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node5 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node7 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node8 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node7 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node8 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node2 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node10 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node5 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node10 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node15 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasdbxref</font> > ] ;
-	node5 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasdbxref</font> > ] ;
-	node6 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node6 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node4 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node7 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node5 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node4 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node3 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node22 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node23 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node12 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
-	node6 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasdbxref</font> > ] ;
-	node22 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node25 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node27 [ color=BLACK, label=< <font point-size='10' color='#336633'>owl:sameAs</font> > ] ;
-	node5 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node24 -> node28 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node12 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node29 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node19 -> node30 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node31 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node6 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node7 -> node32 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node29 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node8 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node7 -> node31 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node5 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node13 -> node30 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node8 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node29 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node6 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node5 -> node31 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node5 -> node29 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node6 -> node32 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node33 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
-	node5 -> node32 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node9 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/504863 node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Evidence-based Network for the Interpretation of Germline Mutant Alleles (ENIGMA)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/504863' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/504863</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bc54e378723b163bff09 node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_581335&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bc54e378723b163bff09' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bc54e378723b163bff09</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2016-09-08&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000300278.2&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bda6f5589149a72a98c4 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ENIGMA BRCA1/2 Classification Criteria (2015)_assertionmethod&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bda6f5589149a72a98c4' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bda6f5589149a72a98c4</font></td></tr><tr><td align='left'>OBO:ERO_0000480</td><td align='left'>&quot;https://submit.ncbi.nlm.nih.gov/ft/byid/hxnfuuxx/enigma_rules_2015-03-26.pdf&quot;</td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/55619 node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_007294.3(BRCA1):c.5535C&gt;A (p.Tyr1845Ter)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/55619' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/55619</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_292:g.172249C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_292p1:p.Tyr1845Ter&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_292t1:c.5535C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000017.10:g.41197752G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000017.11:g.43045735G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_005905.2:g.172249C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_007294.3:c.5535C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_007299.3:c.*49C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_009225.1:p.Tyr1845Ter&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NR_027676.1:n.5671C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;U14680.1:n.5654C&gt;A&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b688d9615bbfa9e0f7df node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b688d9615bbfa9e0f7df</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b688d9615bbfa9e0f7df' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b688d9615bbfa9e0f7df</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b0c37985b4c9880212d8 node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b0c37985b4c9880212d8</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b0c37985b4c9880212d8' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b0c37985b4c9880212d8</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b9abe7978a362ddcafa3 node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b9abe7978a362ddcafa3</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b9abe7978a362ddcafa3' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b9abe7978a362ddcafa3</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b56afa35b1b567770fbb node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b9abe7978a362ddcafa3_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b56afa35b1b567770fbb' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b56afa35b1b567770fbb</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2015-10-02&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000326352.3&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b6766a2d182e85633617 node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;CIMBA Mutation Classification guidelines May 2016_assertionmethod&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b6766a2d182e85633617' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b6766a2d182e85633617</font></td></tr><tr><td align='left'>OBO:ERO_0000480</td><td align='left'>&quot;https://submit.ncbi.nlm.nih.gov/ft/byid/MIHuUwlX/CIMBA_Mutation_Classification_guidelines_May16.pdf&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b4605648dac1f7f6892e node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b9abe7978a362ddcafa3_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b4605648dac1f7f6892e' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b4605648dac1f7f6892e</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b0d65d10d0cc3ce2e885 node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b0c37985b4c9880212d8_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b0d65d10d0cc3ce2e885' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b0d65d10d0cc3ce2e885</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b983c5b3dfc4bf86a358 node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:b4605648dac1f7f6892eSEPIO:0000067&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b983c5b3dfc4bf86a358' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b983c5b3dfc4bf86a358</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/504196 node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Breast Cancer Information Core (BIC) (BRCA1)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/504196' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/504196</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000112698 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000112698</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000112698' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000112698</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# http://omim.org/entry/604370 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Breast-ovarian cancer, familial 1&quot;</B></td></tr><tr><td href='http://omim.org/entry/604370' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/604370</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b4c2e0322314fefb6631 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b4c2e0322314fefb6631' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b4c2e0322314fefb6631</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001483 node20
-node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000037 node21
-node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b5ac7f4700a842b45cea node22
-node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b688d9615bbfa9e0f7df_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b5ac7f4700a842b45cea' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b5ac7f4700a842b45cea</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505954 node23
-node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Consortium of Investigators of Modifiers of BRCA1/2 (CIMBA), c/o University of Cambridge&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505954' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505954</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b1d69744e34b3b2497fe node24
-node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;curation&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b1d69744e34b3b2497fe' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b1d69744e34b3b2497fe</font></td></tr></table> > ] 
-# https://data.monarchinitiative.org/ttl/RCV000112698.nt node25
-node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000112698.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000112698.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000112698.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node26
-node26 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977 node27
-node27 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000081 node28
-node28 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000081</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000081' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000081</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b26b049ffa3f09ecff76 node29
-node29 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_262469&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b26b049ffa3f09ecff76' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b26b049ffa3f09ecff76</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000145571.1&quot;</td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000067 node30
-node30 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000840 node31
-node31 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
-# http://purl.org/oban/association node32
-node32 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/672 node33
-node33 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/672</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/672' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/672</font></td></tr></table> > ] 
+	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node4 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node1 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node6 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node4 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node1 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node13 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node10 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node10 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node4 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node1 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node15 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node19 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node20 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node2 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node2 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node2 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node15 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node4 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node16 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node16 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node2 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node1 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
+	node22 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node4 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node2 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node17 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node6 -> node27 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node12 -> node28 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node23 -> node29 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node22 -> node30 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node19 -> node31 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node19 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node31 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node22 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node10 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node30 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node2 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node32 -> node33 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node17 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node2 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node4 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node19 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node17 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node27 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node1 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
+	node10 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node0 -> node28 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node22 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+# https://monarchinitiative.org/.well-known/genid/bda6f5589149a72a98c4 node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ENIGMA BRCA1/2 Classification Criteria (2015)_assertionmethod&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bda6f5589149a72a98c4' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bda6f5589149a72a98c4</font></td></tr><tr><td align='left'>OBO:ERO_0000480</td><td align='left'>&quot;https://submit.ncbi.nlm.nih.gov/ft/byid/hxnfuuxx/enigma_rules_2015-03-26.pdf&quot;</td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/55619 node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_007294.3(BRCA1):c.5535C&gt;A (p.Tyr1845Ter)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/55619' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/55619</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_292:g.172249C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_292p1:p.Tyr1845Ter&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_292t1:c.5535C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000017.10:g.41197752G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000017.11:g.43045735G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_005905.2:g.172249C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_007294.3:c.5535C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_007299.3:c.*49C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_009225.1:p.Tyr1845Ter&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NR_027676.1:n.5671C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;U14680.1:n.5654C&gt;A&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b688d9615bbfa9e0f7df node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b688d9615bbfa9e0f7df</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b688d9615bbfa9e0f7df' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b688d9615bbfa9e0f7df</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000840 node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b0c37985b4c9880212d8 node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b0c37985b4c9880212d8</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b0c37985b4c9880212d8' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b0c37985b4c9880212d8</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b4605648dac1f7f6892e node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b9abe7978a362ddcafa3_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b4605648dac1f7f6892e' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b4605648dac1f7f6892e</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# http://omim.org/entry/604370 node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Breast-ovarian cancer, familial 1&quot;</B></td></tr><tr><td href='http://omim.org/entry/604370' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/604370</font></td></tr></table> > ] 
+# http://purl.org/oban/association node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b9abe7978a362ddcafa3 node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b9abe7978a362ddcafa3</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b9abe7978a362ddcafa3' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b9abe7978a362ddcafa3</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977 node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b6766a2d182e85633617 node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;CIMBA Mutation Classification guidelines May 2016&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b6766a2d182e85633617' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b6766a2d182e85633617</font></td></tr><tr><td align='left'>OBO:ERO_0000480</td><td align='left'>&quot;https://submit.ncbi.nlm.nih.gov/ft/byid/MIHuUwlX/CIMBA_Mutation_Classification_guidelines_May16.pdf&quot;</td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/504196 node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Breast Cancer Information Core (BIC) (BRCA1)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/504196' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/504196</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b5ac7f4700a842b45cea node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b688d9615bbfa9e0f7df_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b5ac7f4700a842b45cea' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b5ac7f4700a842b45cea</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b0d65d10d0cc3ce2e885 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b0c37985b4c9880212d8_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b0d65d10d0cc3ce2e885' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b0d65d10d0cc3ce2e885</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b26b049ffa3f09ecff76 node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_262469&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b26b049ffa3f09ecff76' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b26b049ffa3f09ecff76</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000145571.1&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001483 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bc54e378723b163bff09 node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b0c37985b4c9880212d8_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bc54e378723b163bff09' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bc54e378723b163bff09</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2016-09-08&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000300278.2&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b4c2e0322314fefb6631 node20
+node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:b5ac7f4700a842b45ceaSEPIO:0000067&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b4c2e0322314fefb6631' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b4c2e0322314fefb6631</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000067 node21
+node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b56afa35b1b567770fbb node22
+node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_625460&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b56afa35b1b567770fbb' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b56afa35b1b567770fbb</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2015-10-02&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000326352.3&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b1d69744e34b3b2497fe node23
+node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;curation&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b1d69744e34b3b2497fe' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b1d69744e34b3b2497fe</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000112698 node24
+node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000112698</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000112698' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000112698</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/672 node25
+node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/672</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/672' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/672</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node26
+node26 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b983c5b3dfc4bf86a358 node27
+node27 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b983c5b3dfc4bf86a358' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b983c5b3dfc4bf86a358</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000037 node28
+node28 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000081 node29
+node29 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000081</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000081' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000081</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505954 node30
+node30 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Consortium of Investigators of Modifiers of BRCA1/2 (CIMBA), c/o University of Cambridge&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505954' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505954</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/504863 node31
+node31 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Evidence-based Network for the Interpretation of Germline Mutant Alleles (ENIGMA)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/504863' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/504863</font></td></tr></table> > ] 
+# https://data.monarchinitiative.org/ttl/RCV000112698.nt node32
+node32 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000112698.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000112698.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000112698.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node33
+node33 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/dot/RCV000112698.dot
+++ b/tests/resources/clinvar/dot/RCV000112698.dot
@@ -1,129 +1,129 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node4 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node1 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node6 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node4 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node10 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node1 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node13 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node10 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node10 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node10 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node4 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node1 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node15 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node19 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node20 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node10 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node2 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node2 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node2 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node15 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node4 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node0 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node1 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node8 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node10 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node4 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node15 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node17 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node14 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
 	node4 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node16 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node10 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node16 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node2 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node1 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
-	node22 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node4 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node2 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node17 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node27 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node12 -> node28 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node23 -> node29 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node22 -> node30 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node19 -> node31 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node19 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node10 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node31 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node22 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node10 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node30 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node2 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node32 -> node33 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node17 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node2 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node4 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node19 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node17 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node27 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node1 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
-	node10 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node0 -> node28 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node22 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-# https://monarchinitiative.org/.well-known/genid/bda6f5589149a72a98c4 node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ENIGMA BRCA1/2 Classification Criteria (2015)_assertionmethod&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bda6f5589149a72a98c4' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bda6f5589149a72a98c4</font></td></tr><tr><td align='left'>OBO:ERO_0000480</td><td align='left'>&quot;https://submit.ncbi.nlm.nih.gov/ft/byid/hxnfuuxx/enigma_rules_2015-03-26.pdf&quot;</td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/55619 node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_007294.3(BRCA1):c.5535C&gt;A (p.Tyr1845Ter)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/55619' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/55619</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_292:g.172249C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_292p1:p.Tyr1845Ter&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_292t1:c.5535C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000017.10:g.41197752G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000017.11:g.43045735G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_005905.2:g.172249C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_007294.3:c.5535C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_007299.3:c.*49C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_009225.1:p.Tyr1845Ter&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NR_027676.1:n.5671C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;U14680.1:n.5654C&gt;A&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b688d9615bbfa9e0f7df node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b688d9615bbfa9e0f7df</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b688d9615bbfa9e0f7df' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b688d9615bbfa9e0f7df</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000840 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b0c37985b4c9880212d8 node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b0c37985b4c9880212d8</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b0c37985b4c9880212d8' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b0c37985b4c9880212d8</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b4605648dac1f7f6892e node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b9abe7978a362ddcafa3_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b4605648dac1f7f6892e' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b4605648dac1f7f6892e</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
-# http://omim.org/entry/604370 node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Breast-ovarian cancer, familial 1&quot;</B></td></tr><tr><td href='http://omim.org/entry/604370' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/604370</font></td></tr></table> > ] 
-# http://purl.org/oban/association node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b9abe7978a362ddcafa3 node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b9abe7978a362ddcafa3</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b9abe7978a362ddcafa3' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b9abe7978a362ddcafa3</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977 node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b6766a2d182e85633617 node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;CIMBA Mutation Classification guidelines May 2016&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b6766a2d182e85633617' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b6766a2d182e85633617</font></td></tr><tr><td align='left'>OBO:ERO_0000480</td><td align='left'>&quot;https://submit.ncbi.nlm.nih.gov/ft/byid/MIHuUwlX/CIMBA_Mutation_Classification_guidelines_May16.pdf&quot;</td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/504196 node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Breast Cancer Information Core (BIC) (BRCA1)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/504196' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/504196</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b5ac7f4700a842b45cea node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b688d9615bbfa9e0f7df_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b5ac7f4700a842b45cea' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b5ac7f4700a842b45cea</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b0d65d10d0cc3ce2e885 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b0c37985b4c9880212d8_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b0d65d10d0cc3ce2e885' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b0d65d10d0cc3ce2e885</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b26b049ffa3f09ecff76 node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_262469&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b26b049ffa3f09ecff76' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b26b049ffa3f09ecff76</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000145571.1&quot;</td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001483 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bc54e378723b163bff09 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b0c37985b4c9880212d8_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bc54e378723b163bff09' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bc54e378723b163bff09</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2016-09-08&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000300278.2&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b4c2e0322314fefb6631 node20
-node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:b5ac7f4700a842b45ceaSEPIO:0000067&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b4c2e0322314fefb6631' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b4c2e0322314fefb6631</font></td></tr></table> > ] 
+	node12 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node4 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node6 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node20 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node17 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node14 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
+	node0 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node11 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node0 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node1 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node24 -> node27 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node17 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node17 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node20 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node4 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node3 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node28 -> node29 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node25 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node14 -> node30 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node14 -> node31 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node17 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node16 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node11 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node17 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node10 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node17 -> node32 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node17 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node14 -> node33 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
+	node4 -> node32 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node20 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node20 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node2 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node7 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node32 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node17 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node2 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node3 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+# https://monarchinitiative.org/.well-known/genid/b56afa35b1b567770fbb node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_625460&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b56afa35b1b567770fbb' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b56afa35b1b567770fbb</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2015-10-02&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000326352.3&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b4605648dac1f7f6892e node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b9abe7978a362ddcafa3_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b4605648dac1f7f6892e' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b4605648dac1f7f6892e</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b26b049ffa3f09ecff76 node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_262469&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b26b049ffa3f09ecff76' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b26b049ffa3f09ecff76</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000145571.1&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b5ac7f4700a842b45cea node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b688d9615bbfa9e0f7df_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b5ac7f4700a842b45cea' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b5ac7f4700a842b45cea</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b688d9615bbfa9e0f7df node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b688d9615bbfa9e0f7df</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b688d9615bbfa9e0f7df' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b688d9615bbfa9e0f7df</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000112698 node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000112698</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000112698' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000112698</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b983c5b3dfc4bf86a358 node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:b4605648dac1f7f6892eSEPIO:0000067&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b983c5b3dfc4bf86a358' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b983c5b3dfc4bf86a358</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b6766a2d182e85633617 node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;CIMBA Mutation Classification guidelines May 2016&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b6766a2d182e85633617' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b6766a2d182e85633617</font></td></tr><tr><td align='left'>OBO:ERO_0000480</td><td align='left'>&quot;https://submit.ncbi.nlm.nih.gov/ft/byid/MIHuUwlX/CIMBA_Mutation_Classification_guidelines_May16.pdf&quot;</td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/504863 node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Evidence-based Network for the Interpretation of Germline Mutant Alleles (ENIGMA)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/504863' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/504863</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b0c37985b4c9880212d8 node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b0c37985b4c9880212d8</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b0c37985b4c9880212d8' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b0c37985b4c9880212d8</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b0d65d10d0cc3ce2e885 node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b0c37985b4c9880212d8_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b0d65d10d0cc3ce2e885' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b0d65d10d0cc3ce2e885</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bda6f5589149a72a98c4 node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ENIGMA BRCA1/2 Classification Criteria (2015)&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bda6f5589149a72a98c4' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bda6f5589149a72a98c4</font></td></tr><tr><td align='left'>OBO:ERO_0000480</td><td align='left'>&quot;https://submit.ncbi.nlm.nih.gov/ft/byid/hxnfuuxx/enigma_rules_2015-03-26.pdf&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000840 node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/55619 node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_007294.3(BRCA1):c.5535C&gt;A (p.Tyr1845Ter)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/55619' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/55619</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_292:g.172249C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_292p1:p.Tyr1845Ter&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;LRG_292t1:c.5535C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000017.10:g.41197752G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000017.11:g.43045735G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_005905.2:g.172249C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_007294.3:c.5535C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_007299.3:c.*49C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_009225.1:p.Tyr1845Ter&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NR_027676.1:n.5671C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;U14680.1:n.5654C&gt;A&quot;</td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/504196 node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Breast Cancer Information Core (BIC) (BRCA1)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/504196' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/504196</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505954 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Consortium of Investigators of Modifiers of BRCA1/2 (CIMBA), c/o University of Cambridge&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505954' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505954</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b9abe7978a362ddcafa3 node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b9abe7978a362ddcafa3</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b9abe7978a362ddcafa3' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b9abe7978a362ddcafa3</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000037 node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bc54e378723b163bff09 node20
+node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_581335&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bc54e378723b163bff09' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bc54e378723b163bff09</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2016-09-08&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000300278.2&quot;</td></tr></table> > ] 
 # http://purl.obolibrary.org/obo/SEPIO_0000067 node21
 node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b56afa35b1b567770fbb node22
-node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_625460&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b56afa35b1b567770fbb' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b56afa35b1b567770fbb</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2015-10-02&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000326352.3&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b1d69744e34b3b2497fe node23
-node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;curation&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b1d69744e34b3b2497fe' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b1d69744e34b3b2497fe</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000112698 node24
-node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000112698</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000112698' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000112698</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/672 node25
-node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/672</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/672' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/672</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node26
-node26 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b983c5b3dfc4bf86a358 node27
-node27 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b983c5b3dfc4bf86a358' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b983c5b3dfc4bf86a358</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000037 node28
-node28 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000081 node29
-node29 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000081</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000081' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000081</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505954 node30
-node30 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Consortium of Investigators of Modifiers of BRCA1/2 (CIMBA), c/o University of Cambridge&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505954' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505954</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/504863 node31
-node31 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Evidence-based Network for the Interpretation of Germline Mutant Alleles (ENIGMA)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/504863' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/504863</font></td></tr></table> > ] 
-# https://data.monarchinitiative.org/ttl/RCV000112698.nt node32
-node32 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000112698.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000112698.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000112698.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node33
-node33 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
+# http://omim.org/entry/604370 node22
+node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Breast-ovarian cancer, familial 1&quot;</B></td></tr><tr><td href='http://omim.org/entry/604370' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/604370</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node23
+node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b1d69744e34b3b2497fe node24
+node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;curation&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b1d69744e34b3b2497fe' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b1d69744e34b3b2497fe</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b4c2e0322314fefb6631 node25
+node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b4c2e0322314fefb6631' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b4c2e0322314fefb6631</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node26
+node26 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000081 node27
+node27 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000081</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000081' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000081</font></td></tr></table> > ] 
+# https://data.monarchinitiative.org/ttl/RCV000112698.nt node28
+node28 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000112698.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000112698.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000112698.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node29
+node29 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977 node30
+node30 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001483 node31
+node31 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
+# http://purl.org/oban/association node32
+node32 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/672 node33
+node33 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/672</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/672' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/672</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/dot/RCV000162061.dot
+++ b/tests/resources/clinvar/dot/RCV000162061.dot
@@ -1,88 +1,88 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node1 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node3 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node5 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node8 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
-	node10 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node1 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
-	node7 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>owl:sameAs</font> > ] ;
-	node8 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000608</font> > ] ;
-	node5 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node8 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
-	node7 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
-	node5 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node3 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node17 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node1 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>owl:sameAs</font> > ] ;
-	node0 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node1 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node5 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasdbxref</font> > ] ;
-	node8 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
-	node12 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node8 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
-	node8 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node4 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node3 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node4 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node9 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node9 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node7 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node8 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000124</font> > ] ;
+	node7 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
+	node3 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
+	node2 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node9 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>dc:source</font> > ] ;
+	node9 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
+	node9 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node2 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node9 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
 	node8 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node5 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>dc:source</font> > ] ;
-	node5 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node7 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node5 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node4 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000124</font> > ] ;
-	node3 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node5 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721 node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Medical Research Institute,Tokyo Medical and Dental University&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/157773 node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018136.4(ASPM):c.10168C&gt;T (p.Arg3390Ter)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/157773' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/157773</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.197056096G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.11:g.197086966G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_015867.1:g.64729C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_018136.4:c.10168C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_060606.3:p.Arg3390Ter&quot;</td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001483 node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bd539326250b4352d101 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b25e1dcae8dd05dc4d16_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd539326250b4352d101' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd539326250b4352d101</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000189126.2&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b8e43a4f4ce6a8409c4a node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b25e1dcae8dd05dc4d16_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b8e43a4f4ce6a8409c4a' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b8e43a4f4ce6a8409c4a</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b25e1dcae8dd05dc4d16 node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b25e1dcae8dd05dc4d16</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b25e1dcae8dd05dc4d16' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b25e1dcae8dd05dc4d16</font></td></tr></table> > ] 
-# http://purl.org/oban/association node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/242641 node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018136.4(ASPM):c.8098C&gt;T (p.Arg2700Ter)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/242641' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/242641</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.197070283G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.11:g.197101153G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_015867.1:g.50542C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_001206846.1:c.4066-4989C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_018136.4:c.8098C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_060606.3:p.Arg2700Ter&quot;</td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/424707 node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018136.4(ASPM):c.[10168C&gt;T];[8098C&gt;T]&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/424707' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/424707</font></td></tr></table> > ] 
-# http://omim.org/entry/608716 node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Primary autosomal recessive microcephaly 5&quot;</B></td></tr><tr><td href='http://omim.org/entry/608716' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/608716</font></td></tr></table> > ] 
-# https://data.monarchinitiative.org/ttl/RCV000162061.nt node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000162061.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000162061.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000162061.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bcff6acb169553f68e9b node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bcff6acb169553f68e9b' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bcff6acb169553f68e9b</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/259266 node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/259266</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/259266' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/259266</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076 node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000402 node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000402</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000402' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000402</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/pubmed/25786579 node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/pubmed/25786579</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/pubmed/25786579' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/pubmed/25786579</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/IAO_0000013 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>IAO_0000013</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/IAO_0000013' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/IAO_0000013</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node20
-node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node21
-node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000162061 node22
-node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000162061</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000162061' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000162061</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000066 node23
-node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000066</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000066' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000066</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node24
-node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000840 node25
-node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
+	node3 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
+	node9 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node9 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node4 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node3 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000608</font> > ] ;
+	node21 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node3 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
+	node7 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node3 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node8 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node17 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node3 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
+	node7 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node19 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+# http://www.ncbi.nlm.nih.gov/pubmed/25786579 node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/pubmed/25786579</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/pubmed/25786579' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/pubmed/25786579</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/IAO_0000013 node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>IAO_0000013</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/IAO_0000013' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/IAO_0000013</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/242641 node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018136.4(ASPM):c.8098C&gt;T (p.Arg2700Ter)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/242641' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/242641</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.197070283G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.11:g.197101153G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_015867.1:g.50542C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_001206846.1:c.4066-4989C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_018136.4:c.8098C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_060606.3:p.Arg2700Ter&quot;</td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/424707 node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018136.4(ASPM):c.[10168C&gt;T];[8098C&gt;T]&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/424707' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/424707</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bd539326250b4352d101 node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b25e1dcae8dd05dc4d16_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd539326250b4352d101' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd539326250b4352d101</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000189126.2&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/157773 node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018136.4(ASPM):c.10168C&gt;T (p.Arg3390Ter)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/157773' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/157773</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.197056096G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.11:g.197086966G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_015867.1:g.64729C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_018136.4:c.10168C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_060606.3:p.Arg3390Ter&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b8e43a4f4ce6a8409c4a node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b25e1dcae8dd05dc4d16_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b8e43a4f4ce6a8409c4a' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b8e43a4f4ce6a8409c4a</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b25e1dcae8dd05dc4d16 node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b25e1dcae8dd05dc4d16</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b25e1dcae8dd05dc4d16' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b25e1dcae8dd05dc4d16</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211 node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/259266 node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/259266</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/259266' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/259266</font></td></tr></table> > ] 
+# http://purl.org/oban/association node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076 node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000162061 node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000162061</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000162061' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000162061</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# http://omim.org/entry/608716 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Primary autosomal recessive microcephaly 5&quot;</B></td></tr><tr><td href='http://omim.org/entry/608716' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/608716</font></td></tr></table> > ] 
+# https://data.monarchinitiative.org/ttl/RCV000162061.nt node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000162061.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000162061.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000162061.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000840 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721 node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Medical Research Institute,Tokyo Medical and Dental University&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000402 node20
+node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000402</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000402' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000402</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bcff6acb169553f68e9b node21
+node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bcff6acb169553f68e9b' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bcff6acb169553f68e9b</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000066 node22
+node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000066</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000066' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000066</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001483 node23
+node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node24
+node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node25
+node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/dot/RCV000162061.dot
+++ b/tests/resources/clinvar/dot/RCV000162061.dot
@@ -1,88 +1,88 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node3 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node4 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node9 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node9 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node7 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node8 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000124</font> > ] ;
-	node7 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
-	node3 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
-	node2 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node9 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>dc:source</font> > ] ;
-	node9 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
-	node9 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node2 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node9 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node8 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node3 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
-	node9 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node9 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node4 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node3 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000608</font> > ] ;
-	node21 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node3 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
-	node7 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node3 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node8 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node17 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node3 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
-	node7 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node19 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-# http://www.ncbi.nlm.nih.gov/pubmed/25786579 node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/pubmed/25786579</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/pubmed/25786579' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/pubmed/25786579</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/IAO_0000013 node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>IAO_0000013</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/IAO_0000013' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/IAO_0000013</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/242641 node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018136.4(ASPM):c.8098C&gt;T (p.Arg2700Ter)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/242641' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/242641</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.197070283G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.11:g.197101153G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_015867.1:g.50542C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_001206846.1:c.4066-4989C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_018136.4:c.8098C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_060606.3:p.Arg2700Ter&quot;</td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/424707 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018136.4(ASPM):c.[10168C&gt;T];[8098C&gt;T]&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/424707' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/424707</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bd539326250b4352d101 node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b25e1dcae8dd05dc4d16_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd539326250b4352d101' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd539326250b4352d101</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000189126.2&quot;</td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/157773 node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018136.4(ASPM):c.10168C&gt;T (p.Arg3390Ter)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/157773' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/157773</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.197056096G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.11:g.197086966G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_015867.1:g.64729C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_018136.4:c.10168C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_060606.3:p.Arg3390Ter&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b8e43a4f4ce6a8409c4a node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b25e1dcae8dd05dc4d16_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b8e43a4f4ce6a8409c4a' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b8e43a4f4ce6a8409c4a</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b25e1dcae8dd05dc4d16 node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b25e1dcae8dd05dc4d16</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b25e1dcae8dd05dc4d16' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b25e1dcae8dd05dc4d16</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211 node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/259266 node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/259266</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/259266' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/259266</font></td></tr></table> > ] 
-# http://purl.org/oban/association node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076 node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000162061 node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000162061</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000162061' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000162061</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
-# http://omim.org/entry/608716 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Primary autosomal recessive microcephaly 5&quot;</B></td></tr><tr><td href='http://omim.org/entry/608716' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/608716</font></td></tr></table> > ] 
-# https://data.monarchinitiative.org/ttl/RCV000162061.nt node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000162061.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000162061.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000162061.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000840 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Medical Research Institute,Tokyo Medical and Dental University&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721</font></td></tr></table> > ] 
+	node1 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node3 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
+	node5 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
+	node8 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node12 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node3 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node7 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node3 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node7 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node17 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node17 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node17 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node7 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
+	node5 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000608</font> > ] ;
+	node17 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node17 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node7 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node1 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node5 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
+	node3 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
+	node5 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node17 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node0 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node5 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
+	node17 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>dc:source</font> > ] ;
+	node17 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node1 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node0 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000124</font> > ] ;
+	node10 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node11 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node0 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+# https://monarchinitiative.org/.well-known/genid/b8e43a4f4ce6a8409c4a node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b25e1dcae8dd05dc4d16_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b8e43a4f4ce6a8409c4a' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b8e43a4f4ce6a8409c4a</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bd539326250b4352d101 node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_336174&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd539326250b4352d101' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd539326250b4352d101</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000189126.2&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/157773 node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018136.4(ASPM):c.10168C&gt;T (p.Arg3390Ter)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/157773' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/157773</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.197056096G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.11:g.197086966G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_015867.1:g.64729C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_018136.4:c.10168C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_060606.3:p.Arg3390Ter&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001483 node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/424707 node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018136.4(ASPM):c.[10168C&gt;T];[8098C&gt;T]&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/424707' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/424707</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/259266 node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/259266</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/259266' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/259266</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/242641 node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018136.4(ASPM):c.8098C&gt;T (p.Arg2700Ter)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/242641' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/242641</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.197070283G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.11:g.197101153G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_015867.1:g.50542C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_001206846.1:c.4066-4989C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_018136.4:c.8098C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_060606.3:p.Arg2700Ter&quot;</td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721 node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Medical Research Institute,Tokyo Medical and Dental University&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# https://data.monarchinitiative.org/ttl/RCV000162061.nt node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000162061.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000162061.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000162061.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bcff6acb169553f68e9b node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bcff6acb169553f68e9b' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bcff6acb169553f68e9b</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/pubmed/25786579 node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/pubmed/25786579</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/pubmed/25786579' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/pubmed/25786579</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/IAO_0000013 node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>IAO_0000013</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/IAO_0000013' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/IAO_0000013</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211 node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b25e1dcae8dd05dc4d16 node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b25e1dcae8dd05dc4d16</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b25e1dcae8dd05dc4d16' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b25e1dcae8dd05dc4d16</font></td></tr></table> > ] 
+# http://omim.org/entry/608716 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Primary autosomal recessive microcephaly 5&quot;</B></td></tr><tr><td href='http://omim.org/entry/608716' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/608716</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000840 node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
 # http://purl.obolibrary.org/obo/GENO_0000402 node20
 node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000402</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000402' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000402</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bcff6acb169553f68e9b node21
-node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bcff6acb169553f68e9b' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bcff6acb169553f68e9b</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000066 node22
-node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000066</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000066' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000066</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001483 node23
-node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node24
-node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node25
-node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000162061 node21
+node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000162061</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000162061' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000162061</font></td></tr></table> > ] 
+# http://purl.org/oban/association node22
+node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node23
+node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000066 node24
+node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000066</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000066' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000066</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node25
+node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/dot/RCV000175394.dot
+++ b/tests/resources/clinvar/dot/RCV000175394.dot
@@ -1,72 +1,72 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
-	node2 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node8 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node9 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node11 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node8 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node2 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node8 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node5 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node8 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node8 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node7 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node7 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node7 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node5 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node8 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node4 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
-	node2 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node8 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494 node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Counsyl&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/194917 node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_000182.4(HADHA):c.2146+1G&gt;A&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/194917' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/194917</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000002.11:g.26414351C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000002.12:g.26191482C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_007121.1:g.58139G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000182.4:c.2146+1G&gt;A&quot;</td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/3030 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/3030</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/3030' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/3030</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bc99926ac85cd459a025 node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Counsyl Autosomal Recessive and X-Linked Classification Criteria (2018)_assertionmethod&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bc99926ac85cd459a025' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bc99926ac85cd459a025</font></td></tr><tr><td align='left'>OBO:ERO_0000480</td><td align='left'>&quot;https://submit.ncbi.nlm.nih.gov/ft/byid/3ys2zqtz/counsyl_autosomal_recessive_and_x-linked_classification_criteria_2018_.pdf&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bec67224cccaa828d90f node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b0c2b8f4b93e10f01eba_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bec67224cccaa828d90f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bec67224cccaa828d90f</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b13b11feeac6001ef4e1 node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_1540968&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b13b11feeac6001ef4e1' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b13b11feeac6001ef4e1</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2017-04-04&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000790664.1&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b0c2b8f4b93e10f01eba node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b0c2b8f4b93e10f01eba</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b0c2b8f4b93e10f01eba' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b0c2b8f4b93e10f01eba</font></td></tr></table> > ] 
-# https://data.monarchinitiative.org/ttl/RCV000175394.nt node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000175394.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000175394.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000175394.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bfcd925176aeb5112036 node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:bec67224cccaa828d90fSEPIO:0000067&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bfcd925176aeb5112036' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bfcd925176aeb5112036</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000067 node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000841 node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000841</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000841' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000841</font></td></tr></table> > ] 
-# http://omim.org/entry/609016 node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Long-chain 3-hydroxyacyl-CoA dehydrogenase deficiency&quot;</B></td></tr><tr><td href='http://omim.org/entry/609016' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/609016</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/150946 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/150946</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/150946' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/150946</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000175394 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000175394</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000175394' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000175394</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000037 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001483 node20
-node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
-# http://purl.org/oban/association node21
-node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219 node22
-node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219</font></td></tr></table> > ] 
+	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node3 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node3 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node2 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node3 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node6 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node3 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node7 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node13 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node1 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node6 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node6 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
+	node0 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node6 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node5 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node3 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node3 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node6 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node6 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
+	node3 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node5 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+# https://monarchinitiative.org/.well-known/genid/bec67224cccaa828d90f node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b0c2b8f4b93e10f01eba_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bec67224cccaa828d90f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bec67224cccaa828d90f</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bfcd925176aeb5112036 node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:bec67224cccaa828d90fSEPIO:0000067&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bfcd925176aeb5112036' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bfcd925176aeb5112036</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494 node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Counsyl&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b0c2b8f4b93e10f01eba node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b0c2b8f4b93e10f01eba</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b0c2b8f4b93e10f01eba' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b0c2b8f4b93e10f01eba</font></td></tr></table> > ] 
+# http://omim.org/entry/609016 node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Long-chain 3-hydroxyacyl-CoA dehydrogenase deficiency&quot;</B></td></tr><tr><td href='http://omim.org/entry/609016' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/609016</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b13b11feeac6001ef4e1 node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_1540968&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b13b11feeac6001ef4e1' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b13b11feeac6001ef4e1</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2017-04-04&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000790664.1&quot;</td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/194917 node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_000182.4(HADHA):c.2146+1G&gt;A&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/194917' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/194917</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000002.11:g.26414351C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000002.12:g.26191482C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_007121.1:g.58139G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000182.4:c.2146+1G&gt;A&quot;</td></tr></table> > ] 
+# https://data.monarchinitiative.org/ttl/RCV000175394.nt node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000175394.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000175394.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000175394.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000175394 node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000175394</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000175394' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000175394</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/150946 node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/150946</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/150946' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/150946</font></td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bc99926ac85cd459a025 node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Counsyl Autosomal Recessive and X-Linked Classification Criteria (2018)&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bc99926ac85cd459a025' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bc99926ac85cd459a025</font></td></tr><tr><td align='left'>OBO:ERO_0000480</td><td align='left'>&quot;https://submit.ncbi.nlm.nih.gov/ft/byid/3ys2zqtz/counsyl_autosomal_recessive_and_x-linked_classification_criteria_2018_.pdf&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000037 node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000067 node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001483 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/3030 node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/3030</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/3030' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/3030</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219 node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219</font></td></tr></table> > ] 
+# http://purl.org/oban/association node20
+node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node21
+node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000841 node22
+node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000841</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000841' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000841</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/dot/RCV000175394.dot
+++ b/tests/resources/clinvar/dot/RCV000175394.dot
@@ -1,72 +1,72 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node0 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node0 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
-	node2 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node8 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node2 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node6 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node7 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node8 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node0 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>owl:sameAs</font> > ] ;
-	node8 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node0 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node3 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node8 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node8 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node8 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasdbxref</font> > ] ;
-	node0 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
-	node8 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node11 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node9 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/194917 node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_000182.4(HADHA):c.2146+1G&gt;A&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/194917' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/194917</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000002.11:g.26414351C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000002.12:g.26191482C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_007121.1:g.58139G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000182.4:c.2146+1G&gt;A&quot;</td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/150946 node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/150946</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/150946' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/150946</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b13b11feeac6001ef4e1 node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b0c2b8f4b93e10f01eba_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b13b11feeac6001ef4e1' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b13b11feeac6001ef4e1</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2017-04-04&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000790664.1&quot;</td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Counsyl&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001483 node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/3030 node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/3030</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/3030' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/3030</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bec67224cccaa828d90f node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b0c2b8f4b93e10f01eba_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bec67224cccaa828d90f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bec67224cccaa828d90f</font></td></tr></table> > ] 
-# https://data.monarchinitiative.org/ttl/RCV000175394.nt node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000175394.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000175394.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000175394.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
+	node2 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node8 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node9 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node11 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node7 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node8 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node2 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node8 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node5 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node8 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node8 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node7 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node7 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node7 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node5 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node8 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node4 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
+	node2 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node8 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494 node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Counsyl&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/194917 node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_000182.4(HADHA):c.2146+1G&gt;A&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/194917' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/194917</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000002.11:g.26414351C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000002.12:g.26191482C&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_007121.1:g.58139G&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_000182.4:c.2146+1G&gt;A&quot;</td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/3030 node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/3030</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/3030' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/3030</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bc99926ac85cd459a025 node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Counsyl Autosomal Recessive and X-Linked Classification Criteria (2018)_assertionmethod&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bc99926ac85cd459a025' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bc99926ac85cd459a025</font></td></tr><tr><td align='left'>OBO:ERO_0000480</td><td align='left'>&quot;https://submit.ncbi.nlm.nih.gov/ft/byid/3ys2zqtz/counsyl_autosomal_recessive_and_x-linked_classification_criteria_2018_.pdf&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bec67224cccaa828d90f node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b0c2b8f4b93e10f01eba_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bec67224cccaa828d90f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bec67224cccaa828d90f</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b13b11feeac6001ef4e1 node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_1540968&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b13b11feeac6001ef4e1' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b13b11feeac6001ef4e1</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2017-04-04&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000790664.1&quot;</td></tr></table> > ] 
 # https://monarchinitiative.org/MONARCH_b0c2b8f4b93e10f01eba node8
 node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b0c2b8f4b93e10f01eba</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b0c2b8f4b93e10f01eba' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b0c2b8f4b93e10f01eba</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bc99926ac85cd459a025 node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Counsyl Autosomal Recessive and X-Linked Classification Criteria (2018)&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bc99926ac85cd459a025' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bc99926ac85cd459a025</font></td></tr><tr><td align='left'>OBO:ERO_0000480</td><td align='left'>&quot;https://submit.ncbi.nlm.nih.gov/ft/byid/3ys2zqtz/counsyl_autosomal_recessive_and_x-linked_classification_criteria_2018_.pdf&quot;</td></tr></table> > ] 
-# http://omim.org/entry/609016 node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Long-chain 3-hydroxyacyl-CoA dehydrogenase deficiency&quot;</B></td></tr><tr><td href='http://omim.org/entry/609016' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/609016</font></td></tr></table> > ] 
+# https://data.monarchinitiative.org/ttl/RCV000175394.nt node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000175394.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000175394.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000175394.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
 # https://monarchinitiative.org/.well-known/genid/bfcd925176aeb5112036 node11
 node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:bec67224cccaa828d90fSEPIO:0000067&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bfcd925176aeb5112036' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bfcd925176aeb5112036</font></td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000841 node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000841</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000841' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000841</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219 node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219</font></td></tr></table> > ] 
-# http://purl.org/oban/association node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000175394 node20
-node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000175394</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000175394' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000175394</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000067 node21
-node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000037 node22
-node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000067 node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000841 node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000841</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000841' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000841</font></td></tr></table> > ] 
+# http://omim.org/entry/609016 node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Long-chain 3-hydroxyacyl-CoA dehydrogenase deficiency&quot;</B></td></tr><tr><td href='http://omim.org/entry/609016' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/609016</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/150946 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/150946</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/150946' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/150946</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000175394 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000175394</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000175394' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000175394</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000037 node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001483 node20
+node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
+# http://purl.org/oban/association node21
+node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219 node22
+node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/dot/RCV000416376.dot
+++ b/tests/resources/clinvar/dot/RCV000416376.dot
@@ -1,96 +1,96 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node1 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node1 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node7 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node7 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node9 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node7 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
+	node5 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node7 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node2 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
+	node2 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
 	node12 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node8 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node3 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node7 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node7 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node3 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node9 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node3 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node10 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node8 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node1 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node3 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
-	node1 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node3 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node1 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node0 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node0 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node8 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node22 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node5 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node1 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node1 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node24 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node3 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
-	node7 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node0 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node0 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node8 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node1 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node4 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-# https://monarchinitiative.org/.well-known/genid/ba583ccbe8979e522d07 node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_966327&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/ba583ccbe8979e522d07' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/ba583ccbe8979e522d07</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2016-01-01&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000494030.1&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b49bb52f6925e2bf5458 node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b49bb52f6925e2bf5458</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b49bb52f6925e2bf5458' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b49bb52f6925e2bf5458</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000416376 node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000416376</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000416376' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000416376</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/375300 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_001999.3(FBN2):c.2945G&gt;T (p.Cys982Phe)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/375300' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/375300</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000005.10:g.128349391C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000005.9:g.127685083C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_008750.1:g.193653G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_001999.3:c.2945G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_001990.2:p.Cys982Phe&quot;</td></tr></table> > ] 
+	node5 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node6 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node8 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node5 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node18 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node6 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node21 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node20 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node18 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node7 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node6 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node6 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node2 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node2 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node18 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node6 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node18 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node6 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node21 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node6 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node4 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node11 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node6 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node7 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node5 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node5 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node7 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+# https://monarchinitiative.org/.well-known/genid/bf70802edf14e71809f4 node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bf70802edf14e71809f4' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bf70802edf14e71809f4</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000066 node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000066</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000066' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000066</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/375300 node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_001999.3(FBN2):c.2945G&gt;T (p.Cys982Phe)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/375300' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/375300</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000005.10:g.128349391C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000005.9:g.127685083C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_008750.1:g.193653G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_001999.3:c.2945G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_001990.2:p.Cys982Phe&quot;</td></tr></table> > ] 
+# http://omim.org/entry/121050 node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Congenital contractural arachnodactyly&quot;</B></td></tr><tr><td href='http://omim.org/entry/121050' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/121050</font></td></tr></table> > ] 
 # https://monarchinitiative.org/.well-known/genid/b1aa769f10db16b258de node4
 node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b49bb52f6925e2bf5458_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b1aa769f10db16b258de' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b1aa769f10db16b258de</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951 node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ACMG Guidelines, 2015&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951</font></td></tr></table> > ] 
-# http://omim.org/entry/121050 node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Congenital contractural arachnodactyly&quot;</B></td></tr><tr><td href='http://omim.org/entry/121050' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/121050</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b6b194b585b6811c6b2a node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b6b194b585b6811c6b2a</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b6b194b585b6811c6b2a' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b6b194b585b6811c6b2a</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b7a901ca0f279b765a76 node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b6b194b585b6811c6b2a_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b7a901ca0f279b765a76' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b7a901ca0f279b765a76</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2016-01-01&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000494030.1&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b4d40a7eefacbfe43164 node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b6b194b585b6811c6b2a_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b4d40a7eefacbfe43164' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b4d40a7eefacbfe43164</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bf70802edf14e71809f4 node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bf70802edf14e71809f4' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bf70802edf14e71809f4</font></td></tr></table> > ] 
-# http://purl.org/oban/association node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b49bb52f6925e2bf5458 node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b49bb52f6925e2bf5458</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b49bb52f6925e2bf5458' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b49bb52f6925e2bf5458</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b6b194b585b6811c6b2a node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b6b194b585b6811c6b2a</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b6b194b585b6811c6b2a' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b6b194b585b6811c6b2a</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b7a901ca0f279b765a76 node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_966327&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b7a901ca0f279b765a76' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b7a901ca0f279b765a76</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2016-01-01&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000494030.1&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951 node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ACMG Guidelines, 2015_assertionmethod&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951</font></td></tr></table> > ] 
+# http://omim.org/entry/154700 node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Marfan syndrome&quot;</B></td></tr><tr><td href='http://omim.org/entry/154700' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/154700</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321 node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505641 node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Diagnostics Division,Centre for DNA Fingerprinting and Diagnostics&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505641' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505641</font></td></tr></table> > ] 
 # https://data.monarchinitiative.org/ttl/RCV000416376.nt node12
 node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000416376.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000416376.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000416376.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
 # http://www.w3.org/2002/07/owl#Ontology node13
 node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/2201 node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/2201</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/2201' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/2201</font></td></tr></table> > ] 
-# http://omim.org/entry/154700 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Marfan syndrome&quot;</B></td></tr><tr><td href='http://omim.org/entry/154700' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/154700</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000841 node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000841</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000841' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000841</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001483 node20
-node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000066 node21
-node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000066</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000066' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000066</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b622f2bdee81c3020a72 node22
-node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b622f2bdee81c3020a72' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b622f2bdee81c3020a72</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321 node23
-node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505641 node24
-node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Diagnostics Division,Centre for DNA Fingerprinting and Diagnostics&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505641' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505641</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000037 node25
-node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node26
-node26 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# http://purl.org/oban/association node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000037 node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000416376 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000416376</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000416376' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000416376</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/ba583ccbe8979e522d07 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b49bb52f6925e2bf5458_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/ba583ccbe8979e522d07' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/ba583ccbe8979e522d07</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2016-01-01&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000494030.1&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b622f2bdee81c3020a72 node20
+node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b622f2bdee81c3020a72' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b622f2bdee81c3020a72</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b4d40a7eefacbfe43164 node21
+node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b6b194b585b6811c6b2a_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b4d40a7eefacbfe43164' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b4d40a7eefacbfe43164</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000841 node22
+node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000841</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000841' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000841</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001483 node23
+node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node24
+node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node25
+node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/2201 node26
+node26 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/2201</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/2201' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/2201</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/dot/RCV000416376.dot
+++ b/tests/resources/clinvar/dot/RCV000416376.dot
@@ -1,96 +1,96 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node1 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node6 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node1 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node1 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node7 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node9 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node0 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node1 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node11 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node13 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node16 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node13 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node1 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasdbxref</font> > ] ;
-	node0 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node5 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node9 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node5 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node13 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>owl:sameAs</font> > ] ;
-	node8 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node13 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
-	node9 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node0 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node9 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node3 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node0 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node4 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasdbxref</font> > ] ;
-	node13 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node6 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node6 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node1 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node6 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
 	node1 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node1 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node13 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
-# https://monarchinitiative.org/.well-known/genid/b7a901ca0f279b765a76 node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_966327&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b7a901ca0f279b765a76' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b7a901ca0f279b765a76</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2016-01-01&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000494030.1&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b6b194b585b6811c6b2a node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b6b194b585b6811c6b2a</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b6b194b585b6811c6b2a' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b6b194b585b6811c6b2a</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000841 node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000841</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000841' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000841</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ACMG Guidelines, 2015_assertionmethod&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b622f2bdee81c3020a72 node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b622f2bdee81c3020a72' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b622f2bdee81c3020a72</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b1aa769f10db16b258de node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b49bb52f6925e2bf5458_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b1aa769f10db16b258de' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b1aa769f10db16b258de</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b49bb52f6925e2bf5458 node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b49bb52f6925e2bf5458</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b49bb52f6925e2bf5458' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b49bb52f6925e2bf5458</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b4d40a7eefacbfe43164 node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b6b194b585b6811c6b2a_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b4d40a7eefacbfe43164' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b4d40a7eefacbfe43164</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bf70802edf14e71809f4 node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bf70802edf14e71809f4' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bf70802edf14e71809f4</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/ba583ccbe8979e522d07 node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b49bb52f6925e2bf5458_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/ba583ccbe8979e522d07' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/ba583ccbe8979e522d07</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2016-01-01&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000494030.1&quot;</td></tr></table> > ] 
-# http://purl.org/oban/association node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# https://data.monarchinitiative.org/ttl/RCV000416376.nt node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000416376.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000416376.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000416376.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/375300 node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_001999.3(FBN2):c.2945G&gt;T (p.Cys982Phe)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/375300' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/375300</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000005.10:g.128349391C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000005.9:g.127685083C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_008750.1:g.193653G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_001999.3:c.2945G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_001990.2:p.Cys982Phe&quot;</td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001483 node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
-# http://omim.org/entry/154700 node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Marfan syndrome&quot;</B></td></tr><tr><td href='http://omim.org/entry/154700' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/154700</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505641 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Diagnostics Division,Centre for DNA Fingerprinting and Diagnostics&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505641' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505641</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
-# http://omim.org/entry/121050 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Congenital contractural arachnodactyly&quot;</B></td></tr><tr><td href='http://omim.org/entry/121050' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/121050</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000416376 node20
-node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000416376</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000416376' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000416376</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node21
-node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node22
-node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+	node1 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node7 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node7 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node9 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node7 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node7 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node12 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node8 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node3 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node7 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node7 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node3 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node9 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node3 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node10 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node8 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node1 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node3 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
+	node1 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node7 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node3 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node1 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node0 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node0 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node8 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node22 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node1 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node1 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node24 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node3 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
+	node7 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node0 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node0 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node8 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node1 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node4 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+# https://monarchinitiative.org/.well-known/genid/ba583ccbe8979e522d07 node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_966327&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/ba583ccbe8979e522d07' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/ba583ccbe8979e522d07</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2016-01-01&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000494030.1&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b49bb52f6925e2bf5458 node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b49bb52f6925e2bf5458</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b49bb52f6925e2bf5458' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b49bb52f6925e2bf5458</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000416376 node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000416376</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000416376' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000416376</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/375300 node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_001999.3(FBN2):c.2945G&gt;T (p.Cys982Phe)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/375300' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/375300</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000005.10:g.128349391C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000005.9:g.127685083C&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_008750.1:g.193653G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_001999.3:c.2945G&gt;T&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_001990.2:p.Cys982Phe&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b1aa769f10db16b258de node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b49bb52f6925e2bf5458_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b1aa769f10db16b258de' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b1aa769f10db16b258de</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951 node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ACMG Guidelines, 2015&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951</font></td></tr></table> > ] 
+# http://omim.org/entry/121050 node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Congenital contractural arachnodactyly&quot;</B></td></tr><tr><td href='http://omim.org/entry/121050' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/121050</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b6b194b585b6811c6b2a node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b6b194b585b6811c6b2a</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b6b194b585b6811c6b2a' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b6b194b585b6811c6b2a</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b7a901ca0f279b765a76 node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b6b194b585b6811c6b2a_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b7a901ca0f279b765a76' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b7a901ca0f279b765a76</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2016-01-01&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000494030.1&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b4d40a7eefacbfe43164 node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b6b194b585b6811c6b2a_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b4d40a7eefacbfe43164' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b4d40a7eefacbfe43164</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bf70802edf14e71809f4 node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bf70802edf14e71809f4' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bf70802edf14e71809f4</font></td></tr></table> > ] 
+# http://purl.org/oban/association node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# https://data.monarchinitiative.org/ttl/RCV000416376.nt node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000416376.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000416376.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000416376.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/2201 node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/2201</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/2201' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/2201</font></td></tr></table> > ] 
+# http://omim.org/entry/154700 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Marfan syndrome&quot;</B></td></tr><tr><td href='http://omim.org/entry/154700' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/154700</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000841 node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000841</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000841' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000841</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001483 node20
+node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000066 node21
+node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000066</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000066' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000066</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b622f2bdee81c3020a72 node22
+node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b622f2bdee81c3020a72' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b622f2bdee81c3020a72</font></td></tr></table> > ] 
 # http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321 node23
 node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000066 node24
-node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000066</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000066' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000066</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505641 node24
+node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Diagnostics Division,Centre for DNA Fingerprinting and Diagnostics&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505641' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505641</font></td></tr></table> > ] 
 # http://purl.obolibrary.org/obo/SEPIO_0000037 node25
 node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/2201 node26
-node26 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/2201</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/2201' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/2201</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node26
+node26 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/dot/RCV000498447.dot
+++ b/tests/resources/clinvar/dot/RCV000498447.dot
@@ -1,83 +1,83 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
-	node4 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node6 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node0 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node8 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node1 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000124</font> > ] ;
-	node0 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node1 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
-	node0 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node0 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
-	node0 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node3 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node8 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node5 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node1 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node2 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node8 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node0 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>dc:source</font> > ] ;
-	node11 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node3 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node0 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node8 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node15 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node3 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-# https://monarchinitiative.org/MONARCH_bcd52bafc1e2e04193a9 node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_bcd52bafc1e2e04193a9</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_bcd52bafc1e2e04193a9' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_bcd52bafc1e2e04193a9</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/be870b3d47783bbdcf05 node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;bcd52bafc1e2e04193a9_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/be870b3d47783bbdcf05' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/be870b3d47783bbdcf05</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/431733 node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/clinvar/variation/431733</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/431733' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/431733</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/425238 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;GRCh37/hg19 1p36.31(chr1:5910699-6038368)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/425238' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/425238</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.5910699_6038368dup&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bd8e0f2fc4633580d875 node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_1142533&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd8e0f2fc4633580d875' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd8e0f2fc4633580d875</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000296057.1&quot;</td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664 node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Center for Human Disease Modeling,Duke University Medical Center&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664</font></td></tr></table> > ] 
-# https://data.monarchinitiative.org/ttl/RCV000498447.nt node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000498447.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000498447.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000498447.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/425239 node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;GRCh37/hg19 1p36.31(chr1:6051187-6158763)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/425239' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/425239</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.6051187_6158763dup&quot;</td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000841 node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000841</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000841' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000841</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001742 node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001742</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001742' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001742</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/pubmed/27486776 node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/pubmed/27486776</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/pubmed/27486776' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/pubmed/27486776</font></td></tr></table> > ] 
-# http://www.omim.org/phenotypicSeries/PS209900 node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Bardet-Biedl syndrome&quot;</B></td></tr><tr><td href='http://www.omim.org/phenotypicSeries/PS209900' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.omim.org/phenotypicSeries/PS209900</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
-# http://purl.org/oban/association node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b664828053687f26b867 node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:be870b3d47783bbdcf05SEPIO:0000066&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b664828053687f26b867' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b664828053687f26b867</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000498447 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000498447</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000498447' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000498447</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/261734 node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/261734</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/261734' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/261734</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/8514 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/8514</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/8514' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/8514</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node20
-node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node21
-node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
+	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node5 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node7 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node0 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
+	node4 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node9 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node13 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node0 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
+	node9 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node13 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node5 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node0 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node4 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node2 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000124</font> > ] ;
+	node2 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node9 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node15 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node13 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node19 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node9 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node4 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node4 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>dc:source</font> > ] ;
+	node11 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node0 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/431733 node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/clinvar/variation/431733</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/431733' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/431733</font></td></tr></table> > ] 
+# http://www.omim.org/phenotypicSeries/PS209900 node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Bardet-Biedl syndrome&quot;</B></td></tr><tr><td href='http://www.omim.org/phenotypicSeries/PS209900' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.omim.org/phenotypicSeries/PS209900</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/be870b3d47783bbdcf05 node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;bcd52bafc1e2e04193a9_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/be870b3d47783bbdcf05' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/be870b3d47783bbdcf05</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_bcd52bafc1e2e04193a9 node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_bcd52bafc1e2e04193a9</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_bcd52bafc1e2e04193a9' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_bcd52bafc1e2e04193a9</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bd8e0f2fc4633580d875 node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_1142533&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd8e0f2fc4633580d875' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd8e0f2fc4633580d875</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000296057.1&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664 node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Center for Human Disease Modeling,Duke University Medical Center&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/425239 node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;GRCh37/hg19 1p36.31(chr1:6051187-6158763)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/425239' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/425239</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.6051187_6158763dup&quot;</td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000498447 node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000498447</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000498447' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000498447</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b664828053687f26b867 node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;research&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b664828053687f26b867' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b664828053687f26b867</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001742 node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001742</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001742' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001742</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/425238 node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;GRCh37/hg19 1p36.31(chr1:5910699-6038368)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/425238' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/425238</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.5910699_6038368dup&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# https://data.monarchinitiative.org/ttl/RCV000498447.nt node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000498447.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000498447.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000498447.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/261734 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/261734</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/261734' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/261734</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001024 node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001024</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001024' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001024</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000841 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000841</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000841' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000841</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/pubmed/27486776 node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/pubmed/27486776</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/pubmed/27486776' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/pubmed/27486776</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/8514 node20
+node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/8514</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/8514' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/8514</font></td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node21
+node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
 # http://purl.obolibrary.org/obo/IAO_0000013 node22
 node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>IAO_0000013</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/IAO_0000013' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/IAO_0000013</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001024 node23
-node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001024</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001024' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001024</font></td></tr></table> > ] 
+# http://purl.org/oban/association node23
+node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
 # http://purl.obolibrary.org/obo/SEPIO_0000066 node24
 node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000066</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000066' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000066</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/dot/RCV000498447.dot
+++ b/tests/resources/clinvar/dot/RCV000498447.dot
@@ -1,83 +1,83 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
-	node4 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node0 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node8 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node4 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node7 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node7 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node2 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node0 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node4 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node7 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node1 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node15 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node16 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node7 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node2 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node15 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasdbxref</font> > ] ;
-	node9 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
-	node15 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node22 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
-	node2 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
-	node8 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000124</font> > ] ;
-	node7 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>dc:source</font> > ] ;
-	node8 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-# https://monarchinitiative.org/.well-known/genid/bd8e0f2fc4633580d875 node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_1142533&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd8e0f2fc4633580d875' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd8e0f2fc4633580d875</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000296057.1&quot;</td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664 node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Center for Human Disease Modeling,Duke University Medical Center&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664</font></td></tr></table> > ] 
+	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
+	node4 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node6 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node0 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node8 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node1 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000124</font> > ] ;
+	node0 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node1 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000382</font> > ] ;
+	node0 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node0 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000841</font> > ] ;
+	node0 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node3 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node8 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node5 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node1 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node2 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node8 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:BFO_0000050</font> > ] ;
+	node0 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>dc:source</font> > ] ;
+	node11 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node3 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node0 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node8 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node15 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node3 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+# https://monarchinitiative.org/MONARCH_bcd52bafc1e2e04193a9 node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_bcd52bafc1e2e04193a9</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_bcd52bafc1e2e04193a9' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_bcd52bafc1e2e04193a9</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/be870b3d47783bbdcf05 node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;bcd52bafc1e2e04193a9_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/be870b3d47783bbdcf05' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/be870b3d47783bbdcf05</font></td></tr></table> > ] 
 # http://www.ncbi.nlm.nih.gov/clinvar/variation/431733 node2
 node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/clinvar/variation/431733</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/431733' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/431733</font></td></tr></table> > ] 
-# http://omim.org/entry/PS209900 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Bardet-Biedl syndrome&quot;</B></td></tr><tr><td href='http://omim.org/entry/PS209900' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/PS209900</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/425239 node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;GRCh37/hg19 1p36.31(chr1:6051187-6158763)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/425239' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/425239</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.6051187_6158763dup&quot;</td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001742 node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001742</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001742' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001742</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_bcd52bafc1e2e04193a9 node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_bcd52bafc1e2e04193a9</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_bcd52bafc1e2e04193a9' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_bcd52bafc1e2e04193a9</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/be870b3d47783bbdcf05 node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;bcd52bafc1e2e04193a9_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/be870b3d47783bbdcf05' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/be870b3d47783bbdcf05</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b664828053687f26b867 node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:be870b3d47783bbdcf05SEPIO:0000066&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b664828053687f26b867' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b664828053687f26b867</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001024 node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001024</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001024' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001024</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/261734 node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/261734</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/261734' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/261734</font></td></tr></table> > ] 
-# http://purl.org/oban/association node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/425238 node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;GRCh37/hg19 1p36.31(chr1:5910699-6038368)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/425238' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/425238</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.5910699_6038368dup&quot;</td></tr></table> > ] 
-# https://data.monarchinitiative.org/ttl/RCV000498447.nt node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000498447.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000498447.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000498447.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000841 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000841</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000841' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000841</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000498447 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000498447</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000498447' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000498447</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000066 node20
-node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000066</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000066' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000066</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/8514 node21
-node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/8514</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/8514' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/8514</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/pubmed/27486776 node22
-node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/pubmed/27486776</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/pubmed/27486776' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/pubmed/27486776</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/IAO_0000013 node23
-node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>IAO_0000013</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/IAO_0000013' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/IAO_0000013</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node24
-node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/425238 node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;GRCh37/hg19 1p36.31(chr1:5910699-6038368)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/425238' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/425238</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.5910699_6038368dup&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bd8e0f2fc4633580d875 node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_1142533&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd8e0f2fc4633580d875' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd8e0f2fc4633580d875</font></td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000296057.1&quot;</td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664 node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Center for Human Disease Modeling,Duke University Medical Center&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664</font></td></tr></table> > ] 
+# https://data.monarchinitiative.org/ttl/RCV000498447.nt node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000498447.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000498447.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000498447.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/425239 node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;GRCh37/hg19 1p36.31(chr1:6051187-6158763)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/425239' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/425239</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000001.10:g.6051187_6158763dup&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000841 node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000841</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000841' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000841</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001742 node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001742</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001742' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001742</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/pubmed/27486776 node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/pubmed/27486776</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/pubmed/27486776' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/pubmed/27486776</font></td></tr></table> > ] 
+# http://www.omim.org/phenotypicSeries/PS209900 node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Bardet-Biedl syndrome&quot;</B></td></tr><tr><td href='http://www.omim.org/phenotypicSeries/PS209900' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.omim.org/phenotypicSeries/PS209900</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# http://purl.org/oban/association node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b664828053687f26b867 node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:be870b3d47783bbdcf05SEPIO:0000066&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b664828053687f26b867' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b664828053687f26b867</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000498447 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000498447</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000498447' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000498447</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/261734 node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/261734</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/261734' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/261734</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/8514 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/8514</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/8514' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/8514</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node20
+node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node21
+node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/IAO_0000013 node22
+node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>IAO_0000013</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/IAO_0000013' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/IAO_0000013</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001024 node23
+node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001024</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001024' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001024</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000066 node24
+node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000066</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000066' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000066</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/dot/RCV000763295.dot
+++ b/tests/resources/clinvar/dot/RCV000763295.dot
@@ -1,125 +1,125 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node0 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node5 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node0 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node10 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node1 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node13 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node9 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node0 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node0 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node1 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node5 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node12 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node15 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
-	node15 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node8 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node21 -> node22 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node9 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node23 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node15 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>owl:sameAs</font> > ] ;
-	node6 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node10 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node11 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node23 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node1 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node0 -> node27 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node9 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node1 -> node28 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasdbxref</font> > ] ;
-	node8 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node1 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node7 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node7 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node7 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node0 -> node29 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node7 -> node29 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node7 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node15 -> node27 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
-	node7 -> node28 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasdbxref</font> > ] ;
-	node0 -> node28 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasdbxref</font> > ] ;
-	node15 -> node30 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
-	node24 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node0 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node7 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node15 -> node31 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node1 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node1 -> node29 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node15 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
-	node10 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node1 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node10 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node8 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node1 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node8 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node12 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node9 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-# https://monarchinitiative.org/MONARCH_bb8218e5dd5e028601ba node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_bb8218e5dd5e028601ba</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_bb8218e5dd5e028601ba' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_bb8218e5dd5e028601ba</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b3135a4d36760903bbc8 node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b3135a4d36760903bbc8</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b3135a4d36760903bbc8' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b3135a4d36760903bbc8</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b2c8ab52a240978b5d07 node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:bd4ef2b55470e2ff6b1cSEPIO:0000067&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b2c8ab52a240978b5d07' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b2c8ab52a240978b5d07</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000067 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
-# http://purl.org/oban/association node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bad61ae6d3fd1072019f node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b04d83bd71a9e5ed689f_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bad61ae6d3fd1072019f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bad61ae6d3fd1072019f</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b29b6ce9b15a8d7587a1 node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:bad61ae6d3fd1072019fSEPIO:0000067&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b29b6ce9b15a8d7587a1' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b29b6ce9b15a8d7587a1</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b04d83bd71a9e5ed689f node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b04d83bd71a9e5ed689f</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b04d83bd71a9e5ed689f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b04d83bd71a9e5ed689f</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/beff008b0bd23fd8ba1f node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b3135a4d36760903bbc8_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/beff008b0bd23fd8ba1f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/beff008b0bd23fd8ba1f</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2018-10-31&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000893958.1&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b8178a5acf773ae10c47 node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_1750397&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b8178a5acf773ae10c47' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b8178a5acf773ae10c47</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2018-10-31&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000893958.1&quot;</td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bb3add3eed5a29ba44e6 node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;bb8218e5dd5e028601ba_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bb3add3eed5a29ba44e6' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bb3add3eed5a29ba44e6</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2018-10-31&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000893958.1&quot;</td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105 node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Fulgent Genetics&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bd4ef2b55470e2ff6b1c node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b3135a4d36760903bbc8_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd4ef2b55470e2ff6b1c' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd4ef2b55470e2ff6b1c</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951 node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ACMG Guidelines, 2015&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000037 node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/31166 node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018082.5(POLR3B):c.1568T&gt;A (p.Val523Glu)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/31166' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/31166</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000012.11:g.106826199T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000012.12:g.106432421T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_031837.1:g.79764T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_018082.5:c.1568T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_060552.4:p.Val523Glu&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;Q9NW08:p.Val523Glu&quot;</td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# http://omim.org/entry/614381 node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Hypomyelinating leukodystrophy 8, with or without oligodontia and/or hypogonadotropic hypogonadism&quot;</B></td></tr><tr><td href='http://omim.org/entry/614381' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/614381</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
-# http://omim.org/entry/146110 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Hypogonadotropic hypogonadism 7 with or without anosmia&quot;</B></td></tr><tr><td href='http://omim.org/entry/146110' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/146110</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node20
-node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# https://data.monarchinitiative.org/ttl/RCV000763295.nt node21
-node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000763295.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000763295.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000763295.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node22
-node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b1e75870cf421cc5377c node23
-node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;bb8218e5dd5e028601ba_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b1e75870cf421cc5377c' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b1e75870cf421cc5377c</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bd0a37bd31ff97afa3ee node24
-node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:b1e75870cf421cc5377cSEPIO:0000067&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd0a37bd31ff97afa3ee' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd0a37bd31ff97afa3ee</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161 node25
-node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node26
-node26 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
-# http://omim.org/entry/607694 node27
-node27 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Hypomyelinating leukodystrophy 7&quot;</B></td></tr><tr><td href='http://omim.org/entry/607694' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/607694</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000763295 node28
-node28 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000763295</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000763295' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000763295</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000840 node29
-node29 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/55703 node30
-node30 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/55703</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/55703' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/55703</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001483 node31
-node31 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
+	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node4 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node4 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node0 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node6 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node9 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
+	node9 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
+	node6 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node14 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node5 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node4 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node0 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node4 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node4 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node0 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node6 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node12 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node5 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node9 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
+	node6 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node20 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node7 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node7 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node4 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node5 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node16 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node5 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node12 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node6 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node16 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node6 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node4 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node16 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node9 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
+	node9 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node4 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node3 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node16 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node6 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node5 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node17 -> node27 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node14 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node6 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node5 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node12 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node5 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node15 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node19 -> node28 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node9 -> node29 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node6 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node22 -> node30 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node9 -> node31 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node12 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+# https://monarchinitiative.org/.well-known/genid/beff008b0bd23fd8ba1f node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b3135a4d36760903bbc8_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/beff008b0bd23fd8ba1f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/beff008b0bd23fd8ba1f</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2018-10-31&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000893958.1&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bd4ef2b55470e2ff6b1c node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b3135a4d36760903bbc8_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd4ef2b55470e2ff6b1c' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd4ef2b55470e2ff6b1c</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b2c8ab52a240978b5d07 node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b2c8ab52a240978b5d07' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b2c8ab52a240978b5d07</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b3135a4d36760903bbc8 node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b3135a4d36760903bbc8</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b3135a4d36760903bbc8' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b3135a4d36760903bbc8</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_bb8218e5dd5e028601ba node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_bb8218e5dd5e028601ba</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_bb8218e5dd5e028601ba' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_bb8218e5dd5e028601ba</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b04d83bd71a9e5ed689f node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b04d83bd71a9e5ed689f</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b04d83bd71a9e5ed689f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b04d83bd71a9e5ed689f</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bad61ae6d3fd1072019f node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b04d83bd71a9e5ed689f_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bad61ae6d3fd1072019f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bad61ae6d3fd1072019f</font></td></tr></table> > ] 
+# http://omim.org/entry/614381 node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Hypomyelinating leukodystrophy 8, with or without oligodontia and/or hypogonadotropic hypogonadism&quot;</B></td></tr><tr><td href='http://omim.org/entry/614381' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/614381</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/31166 node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018082.5(POLR3B):c.1568T&gt;A (p.Val523Glu)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/31166' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/31166</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000012.11:g.106826199T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000012.12:g.106432421T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_031837.1:g.79764T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_018082.5:c.1568T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_060552.4:p.Val523Glu&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;Q9NW08:p.Val523Glu&quot;</td></tr></table> > ] 
+# http://omim.org/entry/146110 node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Hypogonadotropic hypogonadism 7 with or without anosmia&quot;</B></td></tr><tr><td href='http://omim.org/entry/146110' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/146110</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/55703 node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/55703</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/55703' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/55703</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bb3add3eed5a29ba44e6 node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;bb8218e5dd5e028601ba_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bb3add3eed5a29ba44e6' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bb3add3eed5a29ba44e6</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2018-10-31&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000893958.1&quot;</td></tr></table> > ] 
+# http://purl.org/oban/association node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b1e75870cf421cc5377c node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;bb8218e5dd5e028601ba_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b1e75870cf421cc5377c' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b1e75870cf421cc5377c</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bd0a37bd31ff97afa3ee node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd0a37bd31ff97afa3ee' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd0a37bd31ff97afa3ee</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b8178a5acf773ae10c47 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b04d83bd71a9e5ed689f_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b8178a5acf773ae10c47' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b8178a5acf773ae10c47</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2018-10-31&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000893958.1&quot;</td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105 node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Fulgent Genetics&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000840 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951 node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ACMG Guidelines, 2015&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b29b6ce9b15a8d7587a1 node20
+node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b29b6ce9b15a8d7587a1' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b29b6ce9b15a8d7587a1</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000763295 node21
+node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000763295</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000763295' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000763295</font></td></tr></table> > ] 
+# https://data.monarchinitiative.org/ttl/RCV000763295.nt node22
+node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000763295.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000763295.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000763295.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000067 node23
+node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node24
+node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# http://omim.org/entry/607694 node25
+node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Hypomyelinating leukodystrophy 7&quot;</B></td></tr><tr><td href='http://omim.org/entry/607694' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/607694</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001483 node26
+node26 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node27
+node27 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000037 node28
+node28 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node29
+node29 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node30
+node30 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161 node31
+node31 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/dot/RCV000763295.dot
+++ b/tests/resources/clinvar/dot/RCV000763295.dot
@@ -1,125 +1,125 @@
 digraph { 
  node [ fontname="DejaVu Sans" ] ; 
-	node0 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node4 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node4 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node0 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node6 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node9 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
-	node9 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
-	node6 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node14 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node5 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node4 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node0 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node4 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node4 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node0 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node6 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node12 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node5 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node9 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
-	node6 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
-	node20 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node2 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node7 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
-	node4 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node5 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node16 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-	node5 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node12 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node6 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
-	node16 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
-	node6 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node4 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node16 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node9 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
-	node9 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node4 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node3 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node16 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node5 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node6 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node5 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node17 -> node27 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node14 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node6 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
-	node5 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
-	node12 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
-	node5 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node15 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node19 -> node28 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node9 -> node29 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
-	node6 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
-	node22 -> node30 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
-	node5 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
-	node9 -> node31 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
-	node12 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
-# https://monarchinitiative.org/.well-known/genid/beff008b0bd23fd8ba1f node0
-node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b3135a4d36760903bbc8_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/beff008b0bd23fd8ba1f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/beff008b0bd23fd8ba1f</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2018-10-31&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000893958.1&quot;</td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000001 node1
-node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bd4ef2b55470e2ff6b1c node2
-node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b3135a4d36760903bbc8_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd4ef2b55470e2ff6b1c' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd4ef2b55470e2ff6b1c</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b2c8ab52a240978b5d07 node3
-node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b2c8ab52a240978b5d07' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b2c8ab52a240978b5d07</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b3135a4d36760903bbc8 node4
-node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b3135a4d36760903bbc8</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b3135a4d36760903bbc8' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b3135a4d36760903bbc8</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_bb8218e5dd5e028601ba node5
-node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_bb8218e5dd5e028601ba</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_bb8218e5dd5e028601ba' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_bb8218e5dd5e028601ba</font></td></tr></table> > ] 
-# https://monarchinitiative.org/MONARCH_b04d83bd71a9e5ed689f node6
-node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b04d83bd71a9e5ed689f</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b04d83bd71a9e5ed689f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b04d83bd71a9e5ed689f</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bad61ae6d3fd1072019f node7
-node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b04d83bd71a9e5ed689f_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bad61ae6d3fd1072019f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bad61ae6d3fd1072019f</font></td></tr></table> > ] 
-# http://omim.org/entry/614381 node8
-node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Hypomyelinating leukodystrophy 8, with or without oligodontia and/or hypogonadotropic hypogonadism&quot;</B></td></tr><tr><td href='http://omim.org/entry/614381' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/614381</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/variation/31166 node9
-node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018082.5(POLR3B):c.1568T&gt;A (p.Val523Glu)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/31166' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/31166</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000012.11:g.106826199T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000012.12:g.106432421T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_031837.1:g.79764T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_018082.5:c.1568T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_060552.4:p.Val523Glu&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;Q9NW08:p.Val523Glu&quot;</td></tr></table> > ] 
-# http://omim.org/entry/146110 node10
-node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Hypogonadotropic hypogonadism 7 with or without anosmia&quot;</B></td></tr><tr><td href='http://omim.org/entry/146110' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/146110</font></td></tr></table> > ] 
-# https://www.ncbi.nlm.nih.gov/gene/55703 node11
-node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/55703</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/55703' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/55703</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bb3add3eed5a29ba44e6 node12
-node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;bb8218e5dd5e028601ba_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bb3add3eed5a29ba44e6' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bb3add3eed5a29ba44e6</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2018-10-31&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000893958.1&quot;</td></tr></table> > ] 
-# http://purl.org/oban/association node13
-node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b1e75870cf421cc5377c node14
-node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;bb8218e5dd5e028601ba_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b1e75870cf421cc5377c' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b1e75870cf421cc5377c</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/bd0a37bd31ff97afa3ee node15
-node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd0a37bd31ff97afa3ee' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd0a37bd31ff97afa3ee</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b8178a5acf773ae10c47 node16
-node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b04d83bd71a9e5ed689f_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b8178a5acf773ae10c47' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b8178a5acf773ae10c47</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2018-10-31&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000893958.1&quot;</td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105 node17
-node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Fulgent Genetics&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/GENO_0000840 node18
-node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951 node19
-node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ACMG Guidelines, 2015&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951</font></td></tr></table> > ] 
-# https://monarchinitiative.org/.well-known/genid/b29b6ce9b15a8d7587a1 node20
-node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b29b6ce9b15a8d7587a1' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b29b6ce9b15a8d7587a1</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/clinvar/RCV000763295 node21
-node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000763295</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000763295' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000763295</font></td></tr></table> > ] 
+	node1 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node2 -> node3 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node2 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node9 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node5 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node11 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
+	node2 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node9 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node9 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node4 -> node15 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node5 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node11 -> node17 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node11 -> node18 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:RO_0002162</font> > ] ;
+	node1 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node1 -> node5 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node5 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node2 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node3 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node9 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node11 -> node24 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node11 -> node25 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000418</font> > ] ;
+	node3 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node3 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node23 -> node27 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node20 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node1 -> node0 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+	node9 -> node20 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000015</font> > ] ;
+	node9 -> node2 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node1 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node9 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node2 -> node9 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node1 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node5 -> node26 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node28 -> node27 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node0 -> node23 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node1 -> node12 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_object</font> > ] ;
+	node3 -> node21 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node20 -> node16 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000041</font> > ] ;
+	node0 -> node29 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node9 -> node1 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000098</font> > ] ;
+	node11 -> node7 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
+	node16 -> node30 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node8 -> node28 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node21 -> node29 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node19 -> node27 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node11 -> node10 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:GENO_0000840</font> > ] ;
+	node1 -> node6 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node20 -> node4 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000018</font> > ] ;
+	node2 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node22 -> node31 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node2 -> node14 [ color=BLACK, label=< <font point-size='10' color='#336633'>oboInOwl:hasDbXref</font> > ] ;
+	node8 -> node29 [ color=BLACK, label=< <font point-size='10' color='#336633'>rdf:type</font> > ] ;
+	node20 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000111</font> > ] ;
+	node21 -> node19 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000085</font> > ] ;
+	node1 -> node13 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_predicate</font> > ] ;
+	node2 -> node11 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBAN:association_has_subject</font> > ] ;
+	node9 -> node8 [ color=BLACK, label=< <font point-size='10' color='#336633'>OBO:SEPIO_0000007</font> > ] ;
+# https://monarchinitiative.org/.well-known/genid/bd4ef2b55470e2ff6b1c node0
+node0 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b3135a4d36760903bbc8_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd4ef2b55470e2ff6b1c' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd4ef2b55470e2ff6b1c</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b3135a4d36760903bbc8 node1
+node1 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b3135a4d36760903bbc8</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b3135a4d36760903bbc8' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b3135a4d36760903bbc8</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_b04d83bd71a9e5ed689f node2
+node2 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_b04d83bd71a9e5ed689f</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_b04d83bd71a9e5ed689f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_b04d83bd71a9e5ed689f</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b8178a5acf773ae10c47 node3
+node3 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ClinVarAssertion_1750397&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b8178a5acf773ae10c47' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b8178a5acf773ae10c47</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2018-10-31&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000893958.1&quot;</td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105 node4
+node4 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Fulgent Genetics&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/beff008b0bd23fd8ba1f node5
+node5 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b3135a4d36760903bbc8_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/beff008b0bd23fd8ba1f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/beff008b0bd23fd8ba1f</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2018-10-31&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000893958.1&quot;</td></tr></table> > ] 
+# http://purl.org/oban/association node6
+node6 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>association</B></td></tr><tr><td href='http://purl.org/oban/association' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.org/oban/association</font></td></tr></table> > ] 
+# http://omim.org/entry/146110 node7
+node7 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Hypogonadotropic hypogonadism 7 with or without anosmia&quot;</B></td></tr><tr><td href='http://omim.org/entry/146110' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/146110</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b1e75870cf421cc5377c node8
+node8 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;bb8218e5dd5e028601ba_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b1e75870cf421cc5377c' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b1e75870cf421cc5377c</font></td></tr></table> > ] 
+# https://monarchinitiative.org/MONARCH_bb8218e5dd5e028601ba node9
+node9 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>MONARCH_bb8218e5dd5e028601ba</B></td></tr><tr><td href='https://monarchinitiative.org/MONARCH_bb8218e5dd5e028601ba' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/MONARCH_bb8218e5dd5e028601ba</font></td></tr></table> > ] 
+# http://omim.org/entry/607694 node10
+node10 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Hypomyelinating leukodystrophy 7&quot;</B></td></tr><tr><td href='http://omim.org/entry/607694' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/607694</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/variation/31166 node11
+node11 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;NM_018082.5(POLR3B):c.1568T&gt;A (p.Val523Glu)&quot;</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/variation/31166' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/variation/31166</font></td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000012.11:g.106826199T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NC_000012.12:g.106432421T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NG_031837.1:g.79764T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NM_018082.5:c.1568T&gt;A&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;NP_060552.4:p.Val523Glu&quot;</td></tr><tr><td align='left'>oboInOwl:hasExactSynonym</td><td align='left'>&quot;Q9NW08:p.Val523Glu&quot;</td></tr></table> > ] 
+# http://omim.org/entry/614381 node12
+node12 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Hypomyelinating leukodystrophy 8, with or without oligodontia and/or hypogonadotropic hypogonadism&quot;</B></td></tr><tr><td href='http://omim.org/entry/614381' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/614381</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/GENO_0000840 node13
+node13 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>GENO_0000840</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/GENO_0000840' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/GENO_0000840</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/clinvar/RCV000763295 node14
+node14 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000763295</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/clinvar/RCV000763295' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/clinvar/RCV000763295</font></td></tr></table> > ] 
+# http://xmlns.com/foaf/0.1/organization node15
+node15 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951 node16
+node16 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;ACMG Guidelines, 2015_assertionmethod&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b23790c2cc493199c951</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SO_0001483 node17
+node17 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/NCBITaxon_9606 node18
+node18 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b29b6ce9b15a8d7587a1 node19
+node19 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b29b6ce9b15a8d7587a1' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b29b6ce9b15a8d7587a1</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bb3add3eed5a29ba44e6 node20
+node20 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;bb8218e5dd5e028601ba_assertion&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bb3add3eed5a29ba44e6' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bb3add3eed5a29ba44e6</font></td></tr><tr><td align='left'>OBO:SEPIO_0000021</td><td align='left'>&quot;2018-10-31&quot;</td></tr><tr><td align='left'>dc:identifier</td><td align='left'>&quot;SCV000893958.1&quot;</td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bad61ae6d3fd1072019f node21
+node21 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;b04d83bd71a9e5ed689f_evidence&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bad61ae6d3fd1072019f' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bad61ae6d3fd1072019f</font></td></tr></table> > ] 
 # https://data.monarchinitiative.org/ttl/RCV000763295.nt node22
 node22 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>RCV000763295.nt</B></td></tr><tr><td href='https://data.monarchinitiative.org/ttl/RCV000763295.nt' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://data.monarchinitiative.org/ttl/RCV000763295.nt</font></td></tr><tr><td align='left'>owl:versionInfo</td><td align='left'>&quot;2019-07-01&quot;</td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000067 node23
-node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/ECO_0000000 node24
-node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
-# http://omim.org/entry/607694 node25
-node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;Hypomyelinating leukodystrophy 7&quot;</B></td></tr><tr><td href='http://omim.org/entry/607694' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://omim.org/entry/607694</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SO_0001483 node26
-node26 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SO_0001483</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SO_0001483' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SO_0001483</font></td></tr></table> > ] 
-# http://xmlns.com/foaf/0.1/organization node27
-node27 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>organization</B></td></tr><tr><td href='http://xmlns.com/foaf/0.1/organization' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://xmlns.com/foaf/0.1/organization</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/SEPIO_0000037 node28
-node28 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
-# http://purl.obolibrary.org/obo/NCBITaxon_9606 node29
-node29 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>NCBITaxon_9606</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/NCBITaxon_9606' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/NCBITaxon_9606</font></td></tr></table> > ] 
-# http://www.w3.org/2002/07/owl#Ontology node30
-node30 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
-# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161 node31
-node31 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/b2c8ab52a240978b5d07 node23
+node23 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;_:bd4ef2b55470e2ff6b1cSEPIO:0000067&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/b2c8ab52a240978b5d07' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/b2c8ab52a240978b5d07</font></td></tr></table> > ] 
+# http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161 node24
+node24 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161</B></td></tr><tr><td href='http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161</font></td></tr></table> > ] 
+# https://www.ncbi.nlm.nih.gov/gene/55703 node25
+node25 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>https://www.ncbi.nlm.nih.gov/gene/55703</B></td></tr><tr><td href='https://www.ncbi.nlm.nih.gov/gene/55703' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://www.ncbi.nlm.nih.gov/gene/55703</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000001 node26
+node26 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000001</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000001' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000001</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000067 node27
+node27 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000067</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000067' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000067</font></td></tr></table> > ] 
+# https://monarchinitiative.org/.well-known/genid/bd0a37bd31ff97afa3ee node28
+node28 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>&quot;clinical testing&quot;</B></td></tr><tr><td href='https://monarchinitiative.org/.well-known/genid/bd0a37bd31ff97afa3ee' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>https://monarchinitiative.org/.well-known/genid/bd0a37bd31ff97afa3ee</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/ECO_0000000 node29
+node29 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>ECO_0000000</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/ECO_0000000' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/ECO_0000000</font></td></tr></table> > ] 
+# http://purl.obolibrary.org/obo/SEPIO_0000037 node30
+node30 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>SEPIO_0000037</B></td></tr><tr><td href='http://purl.obolibrary.org/obo/SEPIO_0000037' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://purl.obolibrary.org/obo/SEPIO_0000037</font></td></tr></table> > ] 
+# http://www.w3.org/2002/07/owl#Ontology node31
+node31 [ shape=none, color=black label=< <table color='#666666' cellborder='0' cellspacing='0' border='1'><tr><td colspan='2' bgcolor='grey'><B>Ontology</B></td></tr><tr><td href='http://www.w3.org/2002/07/owl#Ontology' bgcolor='#eeeeee' colspan='2'><font point-size='10' color='#6666ff'>http://www.w3.org/2002/07/owl#Ontology</font></td></tr></table> > ] 
 }

--- a/tests/resources/clinvar/expected/RCV000087646.ttl
+++ b/tests/resources/clinvar/expected/RCV000087646.ttl
@@ -4,7 +4,7 @@
     OBAN:association_has_object <http://omim.org/entry/130050> ;
     OBAN:association_has_predicate OBO:GENO_0000840 ;
     OBAN:association_has_subject <http://www.ncbi.nlm.nih.gov/clinvar/variation/101408> ;
-    oboInOwl:hasdbxref ClinVar:RCV000087646 .
+    oboInOwl:hasDbXref ClinVar:RCV000087646 .
 
 <http://www.ncbi.nlm.nih.gov/clinvar/submitters/1058> a foaf:organization ;
     rdfs:label "Collagen Diagnostic Laboratory,University of Washington" .

--- a/tests/resources/clinvar/expected/RCV000112698.ttl
+++ b/tests/resources/clinvar/expected/RCV000112698.ttl
@@ -74,7 +74,7 @@ BNODE:b5ac7f4700a842b45cea a OBO:ECO_0000000 ;
     OBAN:association_has_object <http://omim.org/entry/604370> ;
     OBAN:association_has_predicate OBO:GENO_0000840 ;
     OBAN:association_has_subject <http://www.ncbi.nlm.nih.gov/clinvar/variation/55619> ;
-    oboInOwl:hasdbxref ClinVar:RCV000112698 .
+    oboInOwl:hasDbXref ClinVar:RCV000112698 .
 
 :MONARCH_b688d9615bbfa9e0f7df a OBAN:association ;
     OBO:SEPIO_0000007 BNODE:b5ac7f4700a842b45cea ;
@@ -84,7 +84,7 @@ BNODE:b5ac7f4700a842b45cea a OBO:ECO_0000000 ;
     OBAN:association_has_object <http://omim.org/entry/604370> ;
     OBAN:association_has_predicate OBO:GENO_0000840 ;
     OBAN:association_has_subject <http://www.ncbi.nlm.nih.gov/clinvar/variation/55619> ;
-    oboInOwl:hasdbxref ClinVar:RCV000112698 .
+    oboInOwl:hasDbXref ClinVar:RCV000112698 .
 
 :MONARCH_b9abe7978a362ddcafa3 a OBAN:association ;
     OBO:SEPIO_0000007 BNODE:b4605648dac1f7f6892e ;
@@ -94,7 +94,7 @@ BNODE:b5ac7f4700a842b45cea a OBO:ECO_0000000 ;
     OBAN:association_has_object <http://omim.org/entry/604370> ;
     OBAN:association_has_predicate OBO:GENO_0000840 ;
     OBAN:association_has_subject <http://www.ncbi.nlm.nih.gov/clinvar/variation/55619> ;
-    oboInOwl:hasdbxref ClinVar:RCV000112698 .
+    oboInOwl:hasDbXref ClinVar:RCV000112698 .
 
 <http://www.ncbi.nlm.nih.gov/clinvar/variation/55619> a OBO:SO_0001483 ;
     rdfs:label "NM_007294.3(BRCA1):c.5535C>A (p.Tyr1845Ter)" ;
@@ -112,6 +112,6 @@ BNODE:b5ac7f4700a842b45cea a OBO:ECO_0000000 ;
         "NP_009225.1:p.Tyr1845Ter",
         "NR_027676.1:n.5671C>A",
         "U14680.1:n.5654C>A" ;
-    owl:sameAs <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977> .
+    oboInOwl:hasDbXref <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=80356977> .
 
 <http://omim.org/entry/604370> rdfs:label "Breast-ovarian cancer, familial 1" .

--- a/tests/resources/clinvar/expected/RCV000162061.ttl
+++ b/tests/resources/clinvar/expected/RCV000162061.ttl
@@ -5,7 +5,7 @@
     OBAN:association_has_object <http://omim.org/entry/608716> ;
     OBAN:association_has_predicate OBO:GENO_0000840 ;
     OBAN:association_has_subject <http://www.ncbi.nlm.nih.gov/clinvar/variation/424707> ;
-    oboInOwl:hasdbxref ClinVar:RCV000162061 .
+    oboInOwl:hasDbXref ClinVar:RCV000162061 .
 
 <http://www.ncbi.nlm.nih.gov/clinvar/submitters/505721> a foaf:organization ;
     rdfs:label "Medical Research Institute,Tokyo Medical and Dental University" .
@@ -19,7 +19,7 @@
         "NG_015867.1:g.64729C>T",
         "NM_018136.4:c.10168C>T",
         "NP_060606.3:p.Arg3390Ter" ;
-    owl:sameAs <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211> .
+    oboInOwl:hasDbXref <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=587783211> .
 
 <http://www.ncbi.nlm.nih.gov/clinvar/variation/242641> a OBO:SO_0001483 ;
     rdfs:label "NM_018136.4(ASPM):c.8098C>T (p.Arg2700Ter)" ;
@@ -31,7 +31,7 @@
         "NM_001206846.1:c.4066-4989C>T",
         "NM_018136.4:c.8098C>T",
         "NP_060606.3:p.Arg2700Ter" ;
-    owl:sameAs <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076> .
+    oboInOwl:hasDbXref <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=730882076> .
 
 <http://www.ncbi.nlm.nih.gov/clinvar/variation/424707> a OBO:GENO_0000402 ;
     rdfs:label "NM_018136.4(ASPM):c.[10168C>T];[8098C>T]" ;

--- a/tests/resources/clinvar/expected/RCV000175394.ttl
+++ b/tests/resources/clinvar/expected/RCV000175394.ttl
@@ -4,7 +4,7 @@
     OBAN:association_has_object <http://omim.org/entry/609016> ;
     OBAN:association_has_predicate OBO:GENO_0000841 ;
     OBAN:association_has_subject <http://www.ncbi.nlm.nih.gov/clinvar/variation/194917> ;
-    oboInOwl:hasdbxref ClinVar:RCV000175394 .
+    oboInOwl:hasDbXref ClinVar:RCV000175394 .
 
 <http://www.ncbi.nlm.nih.gov/clinvar/submitters/320494> a foaf:organization ;
     rdfs:label "Counsyl" .
@@ -19,7 +19,7 @@
         "NC_000002.12:g.26191482C>T",
         "NG_007121.1:g.58139G>A",
         "NM_000182.4:c.2146+1G>A" ;
-    owl:sameAs <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219> .
+    oboInOwl:hasDbXref <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=794727219> .
 
 BNODE:b13b11feeac6001ef4e1 a OBO:SEPIO_0000001 ;
     rdfs:label "ClinVarAssertion_1540968",

--- a/tests/resources/clinvar/expected/RCV000416376.ttl
+++ b/tests/resources/clinvar/expected/RCV000416376.ttl
@@ -31,7 +31,7 @@ BNODE:bf70802edf14e71809f4 a OBO:SEPIO_0000066 ;
     OBAN:association_has_object <http://omim.org/entry/121050> ;
     OBAN:association_has_predicate OBO:GENO_0000841 ;
     OBAN:association_has_subject <http://www.ncbi.nlm.nih.gov/clinvar/variation/375300> ;
-    oboInOwl:hasdbxref ClinVar:RCV000416376 .
+    oboInOwl:hasDbXref ClinVar:RCV000416376 .
 
 :MONARCH_b6b194b585b6811c6b2a a OBAN:association ;
     OBO:SEPIO_0000007 BNODE:b4d40a7eefacbfe43164 ;
@@ -40,7 +40,7 @@ BNODE:bf70802edf14e71809f4 a OBO:SEPIO_0000066 ;
     OBAN:association_has_object <http://omim.org/entry/154700> ;
     OBAN:association_has_predicate OBO:GENO_0000841 ;
     OBAN:association_has_subject <http://www.ncbi.nlm.nih.gov/clinvar/variation/375300> ;
-    oboInOwl:hasdbxref ClinVar:RCV000416376 .
+    oboInOwl:hasDbXref ClinVar:RCV000416376 .
 
 <http://omim.org/entry/121050> rdfs:label "Congenital contractural arachnodactyly" .
 
@@ -60,7 +60,7 @@ BNODE:bf70802edf14e71809f4 a OBO:SEPIO_0000066 ;
         "NG_008750.1:g.193653G>T",
         "NM_001999.3:c.2945G>T",
         "NP_001990.2:p.Cys982Phe" ;
-    owl:sameAs <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321> .
+    oboInOwl:hasDbXref <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=1057519321> .
 
 BNODE:b1aa769f10db16b258de a OBO:ECO_0000000 ;
     rdfs:label "b49bb52f6925e2bf5458_evidence" ;

--- a/tests/resources/clinvar/expected/RCV000498447.ttl
+++ b/tests/resources/clinvar/expected/RCV000498447.ttl
@@ -2,10 +2,10 @@
     OBO:SEPIO_0000007 BNODE:be870b3d47783bbdcf05 ;
     OBO:SEPIO_0000015 BNODE:bd8e0f2fc4633580d875 ;
     dc:source <http://www.ncbi.nlm.nih.gov/pubmed/27486776> ;
-    OBAN:association_has_object OMIM:PS209900 ;
+    OBAN:association_has_object OMIMPS:PS209900 ;
     OBAN:association_has_predicate OBO:GENO_0000841 ;
     OBAN:association_has_subject <http://www.ncbi.nlm.nih.gov/clinvar/variation/431733> ;
-    oboInOwl:hasdbxref ClinVar:RCV000498447 .
+    oboInOwl:hasDbXref ClinVar:RCV000498447 .
 
 <http://www.ncbi.nlm.nih.gov/clinvar/submitters/505664> a foaf:organization ;
     rdfs:label "Center for Human Disease Modeling,Duke University Medical Center" .
@@ -26,7 +26,7 @@
 <http://www.ncbi.nlm.nih.gov/clinvar/variation/431733> a OBO:SO_0001024 ;
     OBO:GENO_0000382 <http://www.ncbi.nlm.nih.gov/clinvar/variation/425238>,
         <http://www.ncbi.nlm.nih.gov/clinvar/variation/425239> ;
-    OBO:GENO_0000841 OMIM:PS209900 ;
+    OBO:GENO_0000841 OMIMPS:PS209900 ;
     OBO:RO_0002162 OBO:NCBITaxon_9606 .
 
 BNODE:b664828053687f26b867 a OBO:SEPIO_0000066 ;
@@ -40,7 +40,7 @@ BNODE:bd8e0f2fc4633580d875 a OBO:SEPIO_0000001 ;
     OBO:SEPIO_0000111 BNODE:be870b3d47783bbdcf05 ;
     dc:identifier "SCV000296057.1" .
 
-OMIM:PS209900 rdfs:label "Bardet-Biedl syndrome" .
+OMIMPS:PS209900 rdfs:label "Bardet-Biedl syndrome" .
 
 <http://www.ncbi.nlm.nih.gov/pubmed/27486776> a OBO:IAO_0000013 .
 

--- a/tests/resources/clinvar/expected/RCV000763295.ttl
+++ b/tests/resources/clinvar/expected/RCV000763295.ttl
@@ -63,7 +63,7 @@ BNODE:bd4ef2b55470e2ff6b1c a OBO:ECO_0000000 ;
     OBAN:association_has_object <http://omim.org/entry/146110> ;
     OBAN:association_has_predicate OBO:GENO_0000840 ;
     OBAN:association_has_subject <http://www.ncbi.nlm.nih.gov/clinvar/variation/31166> ;
-    oboInOwl:hasdbxref ClinVar:RCV000763295 .
+    oboInOwl:hasDbXref ClinVar:RCV000763295 .
 
 :MONARCH_b3135a4d36760903bbc8 a OBAN:association ;
     OBO:SEPIO_0000007 BNODE:bd4ef2b55470e2ff6b1c ;
@@ -73,7 +73,7 @@ BNODE:bd4ef2b55470e2ff6b1c a OBO:ECO_0000000 ;
     OBAN:association_has_object <http://omim.org/entry/614381> ;
     OBAN:association_has_predicate OBO:GENO_0000840 ;
     OBAN:association_has_subject <http://www.ncbi.nlm.nih.gov/clinvar/variation/31166> ;
-    oboInOwl:hasdbxref ClinVar:RCV000763295 .
+    oboInOwl:hasDbXref ClinVar:RCV000763295 .
 
 :MONARCH_bb8218e5dd5e028601ba a OBAN:association ;
     OBO:SEPIO_0000007 BNODE:b1e75870cf421cc5377c ;
@@ -83,7 +83,7 @@ BNODE:bd4ef2b55470e2ff6b1c a OBO:ECO_0000000 ;
     OBAN:association_has_object <http://omim.org/entry/607694> ;
     OBAN:association_has_predicate OBO:GENO_0000840 ;
     OBAN:association_has_subject <http://www.ncbi.nlm.nih.gov/clinvar/variation/31166> ;
-    oboInOwl:hasdbxref ClinVar:RCV000763295 .
+    oboInOwl:hasDbXref ClinVar:RCV000763295 .
 
 <http://www.ncbi.nlm.nih.gov/clinvar/submitters/500105> a foaf:organization ;
     rdfs:label "Fulgent Genetics" .
@@ -101,7 +101,7 @@ BNODE:bd4ef2b55470e2ff6b1c a OBO:ECO_0000000 ;
         "NM_018082.5:c.1568T>A",
         "NP_060552.4:p.Val523Glu",
         "Q9NW08:p.Val523Glu" ;
-    owl:sameAs <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161> .
+    oboInOwl:hasDbXref <http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=138249161> .
 
 BNODE:b23790c2cc493199c951 a OBO:SEPIO_0000037 ;
     rdfs:label "ACMG Guidelines, 2015",


### PR DESCRIPTION
In https://github.com/monarch-initiative/dipper/pull/729 I made ClinVar variants and their xref dbSNP ids equivalent, whereas previously they were xrefs.  This has caused a number of clique merge bugs in the latest load, for example:
https://www.ncbi.nlm.nih.gov/clinvar/variation/31915/
https://www.ncbi.nlm.nih.gov/clinvar/variation/21303/