### PR TITLE
Fix parse errors animalqtldb flybase mmrrc

### DIFF
--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -96,7 +96,7 @@ class AnimalQTLdb(Source):
         'gene_id_src',
         'gene_id_type',
         'empty2'
-     ]
+    ]
 
     gene_info_columns = [  # columns from *.gene_info.gz files
         'tax_id',
@@ -320,8 +320,8 @@ class AnimalQTLdb(Source):
                         continue
                     else:
                         if len(row) != len(self.gene_info_columns):
-                            LOG.warning("Problem parsing\n" +
-                                        "in %s row %s\ngot %s cols but expected %s",
+                            LOG.warning("Problem parsing in %s row %s\n"
+                                        "got %s cols but expected %s",
                                         gene_info_file, row, len(row),
                                         len(self.gene_info_columns))
                         self.gene_info.append(str(row[1]))  # tossing lots of good stuff
@@ -387,8 +387,8 @@ class AnimalQTLdb(Source):
                 line_counter += 1
 
                 if len(row) != len(self.qtl_columns):
-                    LOG.warning("Problem parsing\n" +
-                                "in %s row %s\ngot %s cols but expected %s",
+                    LOG.warning("Problem parsing in %s row %s\n"
+                                "got %s cols but expected %s",
                                 raw, row, len(row), len(self.qtl_columns))
                     continue
                 else:
@@ -635,7 +635,7 @@ class AnimalQTLdb(Source):
                     continue
 
                 if len(row) != len(self.gff_columns):
-                    LOG.warning("Problem parsing\n" +
+                    LOG.warning("Problem parsing in %s row %s\n"
                                 "got %s cols but expected %s",
                                 raw, row, len(row), len(self.gff_columns))
                     continue

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -137,12 +137,6 @@ class AnimalQTLdb(Source):
             'curie': 'cattleQTL',
             'columns': gff_columns
         },
-        # disabling this for now
-        # 'cattle_umd_bp': {
-        #   'file': 'QTL_UMD_3.1.gff.txt.gz',
-        #   'url': AQDL + '/tmp/QTL_UMD_3.1.gff.txt.gz',
-        #   'curie': 'cattleQTL',
-        # },
         'cattle_cm': {
             'file': 'cattle_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/cattle_QTLdata.txt',
@@ -658,8 +652,9 @@ class AnimalQTLdb(Source):
                                 raw, row, len(row), len(col))
                     continue
                 else:
-                    # not sure we need to do this 'non-positional mapping' with GFF -
-                    # columns in GFF are probably not going to change anytime soon
+                    # Not sure we need to do this 'non-positional mapping' with GFF -
+                    # columns in GFF are probably not going to change anytime soon.
+                    # Doing this anyway for consistency
                     chromosome = row[col.index('chromosome')].strip()
                     # qtl_source = row[col.index('qtl_source')].strip()
                     # qtl_type = row[col.index('qtl_type')].strip()

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -311,11 +311,12 @@ class AnimalQTLdb(Source):
             LOG.info('Ingesting %s', gene_info_file)
             with gzip.open(gene_info_file, 'rt') as gi_gz:
                 filereader = csv.reader(gi_gz, delimiter='\t')
-                header = next(filereader)
-                header[0] = re.sub('^#', '', header[0])
+                # skipping header checking, b/c not all of these gene_info files have
+                # headers
                 col = self.files[src_key]['columns']
-                self.check_fileheader(col, header)
                 for row in filereader:
+                    if re.match('^#', row[0][0]):
+                        continue
                     if len(row) != len(col):
                         LOG.warning("Problem parsing in %s row %s\n"
                                     "got %s cols but expected %s",
@@ -425,7 +426,8 @@ class AnimalQTLdb(Source):
                     # variance = row[col.index('variance')].strip()
                     # bayes_value = row[col.index('bayes_value')].strip()
                     # likelihood_ratio = row[col.index('likelihood_ratio')].strip()
-                    # trait_iddom_effect = row[col.index('trait_iddom_effect')].strip()
+                    trait_id = row[col.index('trait_id')].strip()
+                    # dom_effect = row[col.index('dom_effect')].strip()
                     # add_effect = row[col.index('add_effect')].strip()
                     pubmed_id = row[col.index('pubmed_id')].strip()
                     gene_id = row[col.index('gene_id')].strip()
@@ -652,18 +654,18 @@ class AnimalQTLdb(Source):
                                 raw, row, len(row), len(col))
                     continue
                 else:
-                    # Not sure we need to do this 'non-positional mapping' with GFF -
-                    # columns in GFF are probably not going to change anytime soon.
-                    # Doing this anyway for consistency
-                    chromosome = row[col.index('chromosome')].strip()
-                    # qtl_source = row[col.index('qtl_source')].strip()
-                    # qtl_type = row[col.index('qtl_type')].strip()
-                    start_bp = row[col.index('start_bp')].strip()
-                    stop_bp = row[col.index('stop_bp')].strip()
-                    # frame = row[col.index('frame')].strip()
-                    strand = row[col.index('strand')].strip()
-                    # score = row[col.index('score')].strip()
-                    attr = row[col.index('attr')].strip()
+                    # Doing this non-positional mapping for consistency, but I'm not
+                    # sure we need to do this for GFF, since columns in GFF are probably
+                    # not going to change anytime soon.
+                    chromosome = row[col.index('SEQNAME')].strip()
+                    # qtl_source = row[col.index('SOURCE')].strip()
+                    # qtl_type = row[col.index('FEATURE')].strip()
+                    start_bp = row[col.index('START')].strip()
+                    stop_bp = row[col.index('END')].strip()
+                    # score = row[col.index('SCORE')].strip()
+                    strand = row[col.index('STRAND')].strip()
+                    # frame = row[col.index('FRAME')].strip()
+                    attr = row[col.index('ATTRIBUTE')].strip()
 
                 example = '''
 Chr.Z   Animal QTLdb    Production_QTL  33954873      34023581...
@@ -797,14 +799,14 @@ Variance="2.94";Dominance_Effect="-0.002";Additive_Effect="0.01
                 if len(row) != len(col):
                     LOG.info("skipping line %d: %s", line_counter, '\t'.join(row))
                     continue
-                vto_id = row[col.index('vto_id')].strip()
-                pto_id = row[col.index('pto_id')].strip()
-                cmo_id = row[col.index('cmo_id')].strip()
-                ato_column = row[col.index('ato_column')].strip()
-                # species = row[col.index('species')].strip()
-                # trait_class = row[col.index('trait_class')].strip()
-                # trait_type = row[col.index('trait_type')].strip()
-                # qtl_count = row[col.index('qtl_count')].strip()
+                vto_id = row[col.index('VT')].strip()
+                pto_id = row[col.index('LPT')].strip()
+                cmo_id = row[col.index('CMO')].strip()
+                ato_column = row[col.index('ATO')].strip()
+                # species = row[col.index('Species')].strip()
+                # trait_class = row[col.index('Class')].strip()
+                # trait_type = row[col.index('Type')].strip()
+                # qtl_count = row[col.index('QTL_Count')].strip()
 
                 ato_id = re.sub(
                     r'ATO #', 'AQTLTrait:', re.sub(

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -267,7 +267,7 @@ class AnimalQTLdb(Source):
             ingest_title='Animal QTL db',
             ingest_url='http://www.animalgenome.org/cgi-bin/QTLdb/index',
             license_url=None,
-            data_rights="'" + AQDL + '/faq#32',
+            data_rights="'" + AQDL + '/faq#32' + "'"
             # file_handle=None
         )
 

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -51,12 +51,91 @@ class AnimalQTLdb(Source):
     GENEINFO = 'ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO'
     GITDIP = 'https://raw.githubusercontent.com/monarch-initiative/dipper/master'
 
+    gff_columns = [  # GFF files (QTL_*.gff.txt.gz) should contain these columns
+        'SEQNAME',
+        'SOURCE',
+        'FEATURE',
+        'START',
+        'END',
+        'SCORE',
+        'STRAND',
+        'FRAME',
+        'ATTRIBUTE'
+    ]
+
+    qtl_columns = [  # columns in *_QTLdata.txt files
+        'qtl_id',
+        'qtl_symbol',
+        'trait_name',
+        'assotype',
+        'empty',
+        'chromosome',
+        'position_cm',
+        'range_cm',
+        'flankmark_a2',
+        'flankmark_a1',
+        'peak_mark',
+        'flankmark_b1',
+        'flankmark_b2',
+        'exp_id',
+        'model_id',
+        'test_base',
+        'psig_level',
+        'lod_score',
+        'ls_mean',
+        'p_values',
+        'f_statistics',
+        'variance',
+        'bayes_value',
+        'likelihood_ratio',
+        'trait_id',
+        'dom_effect',
+        'add_effect',
+        'pubmed_id',
+        'gene_id',
+        'gene_id_src',
+        'gene_id_type',
+        'empty2'
+     ]
+
+    gene_info_columns = [  # columns from *.gene_info.gz files
+        'tax_id',
+        'GeneID',
+        'Symbol',
+        'LocusTag',
+        'Synonyms',
+        'dbXrefs',
+        'chromosome',
+        'map_location',
+        'description',
+        'type_of_gene',
+        'Symbol_from_nomenclature_authority',
+        'Full_name_from_nomenclature_authority',
+        'Nomenclature_status',
+        'Other_designations',
+        'Modification_date',
+        'Feature_type'
+    ]
+
+    trait_mapping_columns = [  # columns in file 'trait_mappings'
+                               # (column info only used for this file at the moment)
+        'VT',
+        'LPT',
+        'CMO',
+        'ATO',
+        'Species',
+        'Class',
+        'Type',
+        'QTL_Count'
+    ]
+
     files = {
         # defaulting to this
         'cattle_bp': {
             'file': 'QTL_Btau_4.6.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_Btau_4.6.gff.txt.gz',
             'curie': 'cattleQTL',
+            'columnns': gff_columns
         },
         # disabling this for now
         # 'cattle_umd_bp': {
@@ -68,51 +147,61 @@ class AnimalQTLdb(Source):
             'file': 'cattle_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/cattle_QTLdata.txt',
             'curie': 'cattleQTL',
+            'columnns': qtl_columns
         },
         'chicken_bp': {
             'file': 'QTL_GG_4.0.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_GG_4.0.gff.txt.gz',
             'curie': 'chickenQTL',
+            'columnns': gff_columns
         },
         'chicken_cm': {
             'file': 'chicken_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/chicken_QTLdata.txt',
             'curie': 'chickenQTL',
+            'columnns': qtl_columns
         },
         'pig_bp': {
             'file': 'QTL_SS_10.2.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_SS_10.2.gff.txt.gz',
             'curie': 'pigQTL',
+            'columnns': gff_columns
         },
         'pig_cm': {
             'file': 'pig_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/pig_QTLdata.txt',
             'curie': 'pigQTL',
+            'columnns': qtl_columns
         },
         'sheep_bp': {
             'file': 'QTL_OAR_3.1.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_OAR_3.1.gff.txt.gz',
             'curie': 'sheepQTL',
+            'columnns': gff_columns
         },
         'sheep_cm': {
             'file': 'sheep_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/sheep_QTLdata.txt',
             'curie': 'sheepQTL',
+            'columnns': qtl_columns
         },
         'horse_bp': {
             'file': 'QTL_EquCab2.0.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_EquCab2.0.gff.txt.gz',
             'curie': 'horseQTL',
+            'columnns': gff_columns
         },
         'horse_cm': {
             'file': 'horse_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/horse_QTLdata.txt',
             'curie': 'horseQTL',
+            'columnns': qtl_columns
         },
         'rainbow_trout_cm': {
             'file': 'rainbow_trout_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/rainbow_trout_QTLdata.txt',
             'curie': 'rainbow_troutQTL',
+            'columnns': qtl_columns
         },
 
         #                  Gene_info from NCBI
@@ -124,37 +213,44 @@ class AnimalQTLdb(Source):
         'Sus_scrofa_info': {
             'file': 'Sus_scrofa.gene_info.gz',
             'url': GENEINFO + '/Mammalia/Sus_scrofa.gene_info.gz',
+            'columnns': gene_info_columns
         },
         # cattle  # "Bos taurus"      # NCBITaxon:9913
         'Bos_taurus_info': {
             'file': 'Bos_taurus.gene_info.gz',
             'url': GENEINFO + '/Mammalia/Bos_taurus.gene_info.gz',
+            'columnns': gene_info_columns
         },
         # chicken  # "Gallus gallus"  # NCBITaxon:9031
         'Gallus_gallus_info': {
             'file': 'Gallus_gallus.gene_info.gz',
             'url': GENEINFO + '/Non-mammalian_vertebrates/Gallus_gallus.gene_info.gz',
+            'columnns': gene_info_columns
         },
         # horse  # "Equus caballus"  # NCBITaxon:9796
         'Equus_caballus_info': {
             'file': 'Equus_caballus.gene_info.gz',
             'url': GITDIP + '/resources/animalqtldb/Equus_caballus.gene_info.gz',
+            'columnns': gene_info_columns
         },
         # sheep  # "Ovis aries"  # NCBITaxon:9940
         'Ovis_aries_info': {
             'file': 'Ovis_aries.gene_info.gz',
             'url': GITDIP + '/resources/animalqtldb/Ovis_aries.gene_info.gz',
+            'columnns': gene_info_columns
         },
         # rainbow trout  # "Oncorhynchus mykiss"  # NCBITaxon:8022
         'Oncorhynchus_mykiss_info': {
             'file': 'Oncorhynchus_mykiss.gene_info.gz',
             'url': GITDIP + '/resources/animalqtldb/Oncorhynchus_mykiss.gene_info.gz',
+            'columnns': gene_info_columns
         },
         ########################################
         # TODO add rainbow_trout_bp when available
         'trait_mappings': {
             'file': 'trait_mappings',
-            'url': AQDL + '/export/trait_mappings.csv'
+            'url': AQDL + '/export/trait_mappings.csv',
+            'columns': trait_mapping_columns
         },
     }
 
@@ -223,11 +319,14 @@ class AnimalQTLdb(Source):
                     if row[0][0] == '#':
                         continue
                     else:
+                        if len(row) != len(self.gene_info_columns):
+                            LOG.warning("Problem parsing %s row %s\n" +
+                                        "in %s row %s\ngot %s cols but expected %s",
+                                        gene_info_file, row, len(row),
+                                        len(self.gene_info_columns))
                         self.gene_info.append(str(row[1]))  # tossing lots of good stuff
             LOG.info(
                 'Gene Info for %s has %i enteries', common_name, len(self.gene_info))
-            # LOG.info('Gene Info entery looks like %s', self.gene_info[5])
-
             build = None
 
             fname_bp = common_name + '_bp'
@@ -240,8 +339,6 @@ class AnimalQTLdb(Source):
                     build = mch.group(1)
                     build_id = self.localtt[build]
                     LOG.info("Build UCSC label is: %s", build_id)
-
-                    # NCBI assembly curie is
 
                     geno.addReferenceGenome(build_id, build, txid_num)
 
@@ -289,7 +386,12 @@ class AnimalQTLdb(Source):
             for row in filereader:
                 line_counter += 1
 
-                try:
+                if len(row) != len(self.qtl_columns):
+                    LOG.warning("Problem parsing %s row %s\n" +
+                                "in %s row %s\ngot %s cols but expected %s",
+                                raw, row, len(row), len(self.qtl_columns))
+                    continue
+                else:
                     (qtl_id,
                      qtl_symbol,
                      trait_name,
@@ -321,10 +423,6 @@ class AnimalQTLdb(Source):
                      gene_id_src,
                      gene_id_type,
                      empty2) = row
-                except ValueError as verror:
-                    LOG.warning("Problem in {} parsing row {}: {}".
-                                format(raw, row, verror))
-                    continue
 
                 if self.test_mode and int(qtl_id) not in self.test_ids:
                     continue
@@ -536,13 +634,14 @@ class AnimalQTLdb(Source):
                 if re.match(r'^#', ' '.join(row)):
                     continue
 
-                try:
+                if len(row) != len(self.gff_columns):
+                    LOG.warning("Problem parsing %s row %s\n" +
+                                "in %s row %s\ngot %s cols but expected %s",
+                                raw, row, len(row), len(self.gff_columns))
+                    continue
+                else:
                     (chromosome, qtl_source, qtl_type, start_bp, stop_bp, frame, strand,
                      score, attr) = row
-                except ValueError as verror:
-                    LOG.warning("Problem in {} parsing row {}: {}".
-                                format(raw, row, verror))
-                    continue
 
                 example = '''
 Chr.Z   Animal QTLdb    Production_QTL  33954873      34023581...

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -320,7 +320,7 @@ class AnimalQTLdb(Source):
                         continue
                     else:
                         if len(row) != len(self.gene_info_columns):
-                            LOG.warning("Problem parsing %s row %s\n" +
+                            LOG.warning("Problem parsing\n" +
                                         "in %s row %s\ngot %s cols but expected %s",
                                         gene_info_file, row, len(row),
                                         len(self.gene_info_columns))
@@ -387,7 +387,7 @@ class AnimalQTLdb(Source):
                 line_counter += 1
 
                 if len(row) != len(self.qtl_columns):
-                    LOG.warning("Problem parsing %s row %s\n" +
+                    LOG.warning("Problem parsing\n" +
                                 "in %s row %s\ngot %s cols but expected %s",
                                 raw, row, len(row), len(self.qtl_columns))
                     continue
@@ -635,8 +635,8 @@ class AnimalQTLdb(Source):
                     continue
 
                 if len(row) != len(self.gff_columns):
-                    LOG.warning("Problem parsing %s row %s\n" +
-                                "in %s row %s\ngot %s cols but expected %s",
+                    LOG.warning("Problem parsing\n" +
+                                "got %s cols but expected %s",
                                 raw, row, len(row), len(self.gff_columns))
                     continue
                 else:

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -135,7 +135,7 @@ class AnimalQTLdb(Source):
             'file': 'QTL_Btau_4.6.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_Btau_4.6.gff.txt.gz',
             'curie': 'cattleQTL',
-            'columnns': gff_columns
+            'columns': gff_columns
         },
         # disabling this for now
         # 'cattle_umd_bp': {
@@ -147,61 +147,61 @@ class AnimalQTLdb(Source):
             'file': 'cattle_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/cattle_QTLdata.txt',
             'curie': 'cattleQTL',
-            'columnns': qtl_columns
+            'columns': qtl_columns
         },
         'chicken_bp': {
             'file': 'QTL_GG_4.0.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_GG_4.0.gff.txt.gz',
             'curie': 'chickenQTL',
-            'columnns': gff_columns
+            'columns': gff_columns
         },
         'chicken_cm': {
             'file': 'chicken_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/chicken_QTLdata.txt',
             'curie': 'chickenQTL',
-            'columnns': qtl_columns
+            'columns': qtl_columns
         },
         'pig_bp': {
             'file': 'QTL_SS_10.2.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_SS_10.2.gff.txt.gz',
             'curie': 'pigQTL',
-            'columnns': gff_columns
+            'columns': gff_columns
         },
         'pig_cm': {
             'file': 'pig_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/pig_QTLdata.txt',
             'curie': 'pigQTL',
-            'columnns': qtl_columns
+            'columns': qtl_columns
         },
         'sheep_bp': {
             'file': 'QTL_OAR_3.1.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_OAR_3.1.gff.txt.gz',
             'curie': 'sheepQTL',
-            'columnns': gff_columns
+            'columns': gff_columns
         },
         'sheep_cm': {
             'file': 'sheep_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/sheep_QTLdata.txt',
             'curie': 'sheepQTL',
-            'columnns': qtl_columns
+            'columns': qtl_columns
         },
         'horse_bp': {
             'file': 'QTL_EquCab2.0.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_EquCab2.0.gff.txt.gz',
             'curie': 'horseQTL',
-            'columnns': gff_columns
+            'columns': gff_columns
         },
         'horse_cm': {
             'file': 'horse_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/horse_QTLdata.txt',
             'curie': 'horseQTL',
-            'columnns': qtl_columns
+            'columns': qtl_columns
         },
         'rainbow_trout_cm': {
             'file': 'rainbow_trout_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/rainbow_trout_QTLdata.txt',
             'curie': 'rainbow_troutQTL',
-            'columnns': qtl_columns
+            'columns': qtl_columns
         },
 
         #                  Gene_info from NCBI
@@ -213,37 +213,37 @@ class AnimalQTLdb(Source):
         'Sus_scrofa_info': {
             'file': 'Sus_scrofa.gene_info.gz',
             'url': GENEINFO + '/Mammalia/Sus_scrofa.gene_info.gz',
-            'columnns': gene_info_columns
+            'columns': gene_info_columns
         },
         # cattle  # "Bos taurus"      # NCBITaxon:9913
         'Bos_taurus_info': {
             'file': 'Bos_taurus.gene_info.gz',
             'url': GENEINFO + '/Mammalia/Bos_taurus.gene_info.gz',
-            'columnns': gene_info_columns
+            'columns': gene_info_columns
         },
         # chicken  # "Gallus gallus"  # NCBITaxon:9031
         'Gallus_gallus_info': {
             'file': 'Gallus_gallus.gene_info.gz',
             'url': GENEINFO + '/Non-mammalian_vertebrates/Gallus_gallus.gene_info.gz',
-            'columnns': gene_info_columns
+            'columns': gene_info_columns
         },
         # horse  # "Equus caballus"  # NCBITaxon:9796
         'Equus_caballus_info': {
             'file': 'Equus_caballus.gene_info.gz',
             'url': GITDIP + '/resources/animalqtldb/Equus_caballus.gene_info.gz',
-            'columnns': gene_info_columns
+            'columns': gene_info_columns
         },
         # sheep  # "Ovis aries"  # NCBITaxon:9940
         'Ovis_aries_info': {
             'file': 'Ovis_aries.gene_info.gz',
             'url': GITDIP + '/resources/animalqtldb/Ovis_aries.gene_info.gz',
-            'columnns': gene_info_columns
+            'columns': gene_info_columns
         },
         # rainbow trout  # "Oncorhynchus mykiss"  # NCBITaxon:8022
         'Oncorhynchus_mykiss_info': {
             'file': 'Oncorhynchus_mykiss.gene_info.gz',
             'url': GITDIP + '/resources/animalqtldb/Oncorhynchus_mykiss.gene_info.gz',
-            'columnns': gene_info_columns
+            'columns': gene_info_columns
         },
         ########################################
         # TODO add rainbow_trout_bp when available
@@ -296,8 +296,9 @@ class AnimalQTLdb(Source):
         else:
             graph = self.graph
 
-        traitmap = '/'.join((self.rawdir, self.files['trait_mappings']['file']))
-        self._process_trait_mappings(traitmap, limit)
+        trait_src_key = 'trait_mappings'
+        traitmap = '/'.join((self.rawdir, self.files[trait_src_key]['file']))
+        self._process_trait_mappings(traitmap, trait_src_key, limit)
 
         geno = Genotype(graph)
         animals = ['chicken', 'pig', 'horse', 'rainbow_trout', 'sheep', 'cattle']
@@ -309,24 +310,25 @@ class AnimalQTLdb(Source):
             taxon_num = taxon_curie.split(':')[1]
             txid_num = taxon_num  # for now
             taxon_word = taxon_label.replace(' ', '_')
+            src_key = taxon_word + '_info'
             gene_info_file = '/'.join((
-                self.rawdir, self.files[taxon_word + '_info']['file']))
+                self.rawdir, self.files[src_key]['file']))
             self.gene_info = list()
             LOG.info('Ingesting %s', gene_info_file)
             with gzip.open(gene_info_file, 'rt') as gi_gz:
                 filereader = csv.reader(gi_gz, delimiter='\t')
+                header = next(filereader)
+                header[0] = re.sub('^#', '', header[0])
+                col = self.files[src_key]['columns']
+                self.check_fileheader(col, header)
                 for row in filereader:
-                    if row[0][0] == '#':
-                        continue
-                    else:
-                        if len(row) != len(self.gene_info_columns):
-                            LOG.warning("Problem parsing in %s row %s\n"
-                                        "got %s cols but expected %s",
-                                        gene_info_file, row, len(row),
-                                        len(self.gene_info_columns))
-                        self.gene_info.append(str(row[1]))  # tossing lots of good stuff
+                    if len(row) != len(col):
+                        LOG.warning("Problem parsing in %s row %s\n"
+                                    "got %s cols but expected %s",
+                                    gene_info_file, row, len(row), len(col))
+                    self.gene_info.append(row[col.index('GeneID')])
             LOG.info(
-                'Gene Info for %s has %i enteries', common_name, len(self.gene_info))
+                'Gene Info for %s has %i entries', common_name, len(self.gene_info))
             build = None
 
             fname_bp = common_name + '_bp'
@@ -344,20 +346,29 @@ class AnimalQTLdb(Source):
 
                 if build_id is not None:
                     self._process_qtls_genomic_location(
-                        '/'.join((self.rawdir, bpfile)), txid_num, build_id, build,
-                        common_name, limit)
+                        '/'.join((self.rawdir, bpfile)),
+                        fname_bp,
+                        txid_num,
+                        build_id,
+                        build,
+                        common_name,
+                        limit)
 
             fname_cm = common_name + '_cm'
             if fname_cm in self.files:
                 cmfile = self.files[fname_cm]['file']
                 self._process_qtls_genetic_location(
-                    '/'.join((self.rawdir, cmfile)), txid_num, common_name, limit)
+                    '/'.join((self.rawdir, cmfile)),
+                    fname_cm,
+                    txid_num,
+                    common_name,
+                    limit)
 
         LOG.info("Finished parsing")
         return
 
     def _process_qtls_genetic_location(
-            self, raw, txid, common_name, limit=None):
+            self, raw, src_key, txid, common_name, limit=None):
         """
         This function processes
 
@@ -367,7 +378,7 @@ class AnimalQTLdb(Source):
         :return:
 
         """
-        aql_curie = self.files[common_name + '_cm']['curie']
+        aql_curie = self.files[src_key]['curie']
 
         if self.test_mode:
             graph = self.testgraph
@@ -383,46 +394,50 @@ class AnimalQTLdb(Source):
         LOG.info("Processing genetic location for %s from %s", taxon_curie, raw)
         with open(raw, 'r', encoding="iso-8859-1") as csvfile:
             filereader = csv.reader(csvfile, delimiter='\t', quotechar='\"')
+            # no header in these files, so no header checking
+
+            col = self.files[src_key]['columns']
+
             for row in filereader:
                 line_counter += 1
 
                 if len(row) != len(self.qtl_columns):
                     LOG.warning("Problem parsing in %s row %s\n"
                                 "got %s cols but expected %s",
-                                raw, row, len(row), len(self.qtl_columns))
+                                raw, row, len(row), len(col))
                     continue
                 else:
-                    (qtl_id,
-                     qtl_symbol,
-                     trait_name,
-                     assotype,
-                     empty,
-                     chromosome,
-                     position_cm,
-                     range_cm,
-                     flankmark_a2,
-                     flankmark_a1,
-                     peak_mark,
-                     flankmark_b1,
-                     flankmark_b2,
-                     exp_id,
-                     model_id,
-                     test_base,
-                     sig_level,
-                     lod_score,
-                     ls_mean,
-                     p_values,
-                     f_statistics,
-                     variance,
-                     bayes_value,
-                     likelihood_ratio,
-                     trait_id, dom_effect,
-                     add_effect,
-                     pubmed_id,
-                     gene_id,
-                     gene_id_src,
-                     gene_id_type,
-                     empty2) = row
+                    qtl_id = row[col.index('qtl_id')].strip()
+                    qtl_symbol = row[col.index('qtl_symbol')].strip()
+                    trait_name = row[col.index('trait_name')].strip()
+                    # assotype = row[col.index('assotype')].strip()
+                    # empty = row[col.index('empty')].strip()
+                    chromosome = row[col.index('chromosome')].strip()
+                    position_cm = row[col.index('position_cm')].strip()
+                    range_cm = row[col.index('range_cm')].strip()
+                    # flankmark_a2 = row[col.index('flankmark_a2')].strip()
+                    # flankmark_a1 = row[col.index('flankmark_a1')].strip()
+                    peak_mark = row[col.index('peak_mark')].strip()
+                    # flankmark_b1 = row[col.index('flankmark_b1')].strip()
+                    # flankmark_b2 = row[col.index('flankmark_b2')].strip()
+                    # exp_id = row[col.index('exp_id')].strip()
+                    # model_id = row[col.index('model_id')].strip()
+                    # test_base = row[col.index('test_base')].strip()
+                    # sig_level = row[col.index('sig_level')].strip()
+                    # lod_score = row[col.index('lod_score')].strip()
+                    # ls_mean = row[col.index('ls_mean')].strip()
+                    p_values = row[col.index('p_values')].strip()
+                    # f_statistics = row[col.index('f_statistics')].strip()
+                    # variance = row[col.index('variance')].strip()
+                    # bayes_value = row[col.index('bayes_value')].strip()
+                    # likelihood_ratio = row[col.index('likelihood_ratio')].strip()
+                    # trait_iddom_effect = row[col.index('trait_iddom_effect')].strip()
+                    # add_effect = row[col.index('add_effect')].strip()
+                    pubmed_id = row[col.index('pubmed_id')].strip()
+                    gene_id = row[col.index('gene_id')].strip()
+                    gene_id_src = row[col.index('gene_id_src')].strip()
+                    # gene_id_type = row[col.index('gene_id_type')].strip()
+                    # empty2 = row[col.index('empty2')].strip()
 
                 if self.test_mode and int(qtl_id) not in self.test_ids:
                     continue
@@ -599,6 +614,7 @@ class AnimalQTLdb(Source):
 
                     assoc.add_association_to_graph()
 
+                # off by one - the following actually gives us (limit + 1) records
                 if not self.test_mode and limit is not None and line_counter > limit:
                     break
 
@@ -606,7 +622,7 @@ class AnimalQTLdb(Source):
         return
 
     def _process_qtls_genomic_location(
-            self, raw, txid, build_id, build_label, common_name, limit=None):
+            self, raw, src_key, txid, build_id, build_label, common_name, limit=None):
         """
         This method
 
@@ -629,19 +645,30 @@ class AnimalQTLdb(Source):
         LOG.info("Processing QTL locations for %s from %s", taxon_curie, raw)
         with gzip.open(raw, 'rt', encoding='ISO-8859-1') as tsvfile:
             reader = csv.reader(tsvfile, delimiter="\t")
+            # no header in GFF, so no header checking
+            col = self.files[src_key]['columns']
             for row in reader:
                 line_counter += 1
                 if re.match(r'^#', ' '.join(row)):
                     continue
 
-                if len(row) != len(self.gff_columns):
+                if len(row) != len(col):
                     LOG.warning("Problem parsing in %s row %s\n"
                                 "got %s cols but expected %s",
-                                raw, row, len(row), len(self.gff_columns))
+                                raw, row, len(row), len(col))
                     continue
                 else:
-                    (chromosome, qtl_source, qtl_type, start_bp, stop_bp, frame, strand,
-                     score, attr) = row
+                    # not sure we need to do this 'non-positional mapping' with GFF -
+                    # columns in GFF are probably not going to change anytime soon
+                    chromosome = row[col.index('chromosome')].strip()
+                    # qtl_source = row[col.index('qtl_source')].strip()
+                    # qtl_type = row[col.index('qtl_type')].strip()
+                    start_bp = row[col.index('start_bp')].strip()
+                    stop_bp = row[col.index('stop_bp')].strip()
+                    # frame = row[col.index('frame')].strip()
+                    strand = row[col.index('strand')].strip()
+                    # score = row[col.index('score')].strip()
+                    attr = row[col.index('attr')].strip()
 
                 example = '''
 Chr.Z   Animal QTLdb    Production_QTL  33954873      34023581...
@@ -747,7 +774,7 @@ Variance="2.94";Dominance_Effect="-0.002";Additive_Effect="0.01
         LOG.info("Done with QTL genomic mappings for %s", taxon_curie)
         return
 
-    def _process_trait_mappings(self, raw, limit=None):
+    def _process_trait_mappings(self, raw, src_key, limit=None):
         """
         This method mapps traits from/to ...
 
@@ -763,17 +790,26 @@ Variance="2.94";Dominance_Effect="-0.002";Additive_Effect="0.01
         line_counter = 0
         model = Model(graph)
 
+        col = self.files[src_key]['columns']
+
         with open(raw, 'r') as csvfile:
             filereader = csv.reader(csvfile, delimiter=',', quotechar='\"')
-            next(filereader, None)  # skip header line
+            header = next(filereader, None)
+            self.check_fileheader(col, header)
             for row in filereader:
                 line_counter += 1
                 # need to skip the last line
-                if len(row) < 8:
+                if len(row) != len(col):
                     LOG.info("skipping line %d: %s", line_counter, '\t'.join(row))
                     continue
-                (vto_id, pto_id, cmo_id, ato_column, species, trait_class,
-                 trait_type, qtl_count) = row
+                vto_id = row[col.index('vto_id')].strip()
+                pto_id = row[col.index('pto_id')].strip()
+                cmo_id = row[col.index('cmo_id')].strip()
+                ato_column = row[col.index('ato_column')].strip()
+                # species = row[col.index('species')].strip()
+                # trait_class = row[col.index('trait_class')].strip()
+                # trait_type = row[col.index('trait_type')].strip()
+                # qtl_count = row[col.index('qtl_count')].strip()
 
                 ato_id = re.sub(
                     r'ATO #', 'AQTLTrait:', re.sub(

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -288,37 +288,43 @@ class AnimalQTLdb(Source):
             filereader = csv.reader(csvfile, delimiter='\t', quotechar='\"')
             for row in filereader:
                 line_counter += 1
-                (qtl_id,
-                 qtl_symbol,
-                 trait_name,
-                 assotype,
-                 empty,
-                 chromosome,
-                 position_cm,
-                 range_cm,
-                 flankmark_a2,
-                 flankmark_a1,
-                 peak_mark,
-                 flankmark_b1,
-                 flankmark_b2,
-                 exp_id,
-                 model_id,
-                 test_base,
-                 sig_level,
-                 lod_score,
-                 ls_mean,
-                 p_values,
-                 f_statistics,
-                 variance,
-                 bayes_value,
-                 likelihood_ratio,
-                 trait_id, dom_effect,
-                 add_effect,
-                 pubmed_id,
-                 gene_id,
-                 gene_id_src,
-                 gene_id_type,
-                 empty2) = row
+
+                try:
+                    (qtl_id,
+                     qtl_symbol,
+                     trait_name,
+                     assotype,
+                     empty,
+                     chromosome,
+                     position_cm,
+                     range_cm,
+                     flankmark_a2,
+                     flankmark_a1,
+                     peak_mark,
+                     flankmark_b1,
+                     flankmark_b2,
+                     exp_id,
+                     model_id,
+                     test_base,
+                     sig_level,
+                     lod_score,
+                     ls_mean,
+                     p_values,
+                     f_statistics,
+                     variance,
+                     bayes_value,
+                     likelihood_ratio,
+                     trait_id, dom_effect,
+                     add_effect,
+                     pubmed_id,
+                     gene_id,
+                     gene_id_src,
+                     gene_id_type,
+                     empty2) = row
+                except ValueError as verror:
+                    LOG.warning("Problem in {} parsing row {}: {}".
+                                format(raw, row, verror))
+                    continue
 
                 if self.test_mode and int(qtl_id) not in self.test_ids:
                     continue
@@ -530,8 +536,14 @@ class AnimalQTLdb(Source):
                 if re.match(r'^#', ' '.join(row)):
                     continue
 
-                (chromosome, qtl_source, qtl_type, start_bp, stop_bp, frame, strand,
-                 score, attr) = row
+                try:
+                    (chromosome, qtl_source, qtl_type, start_bp, stop_bp, frame, strand,
+                     score, attr) = row
+                except ValueError as verror:
+                    LOG.warning("Problem in {} parsing row {}: {}".
+                                format(raw, row, verror))
+                    continue
+
                 example = '''
 Chr.Z   Animal QTLdb    Production_QTL  33954873      34023581...
 QTL_ID=2242;Name="Spleen percentage";Abbrev="SPLP";PUBMED_ID=17012160;trait_ID=2234;

--- a/dipper/sources/FlyBase.py
+++ b/dipper/sources/FlyBase.py
@@ -416,7 +416,11 @@ class FlyBase(PostgreSQLSource):
 
         col = self.files[src_key]['columns']
 
-        with gzip.open(raw, 'rt') as tsvfile:
+        # JR - I've set encoding to latin-1 to fix the UnicodeDecodeError that happens
+        # when the default encoding (utf-8) is used. This possibly will break if/when
+        # the encoding of this file upstream at Flybase is changed to utf-8. If so,
+        # trying setting encoding='utf-8' below
+        with gzip.open(raw, 'rt', encoding='latin-1') as tsvfile:
             reader = csv.reader(tsvfile, delimiter='\t')
             # skip first four lines
             for _ in range(0, 2):

--- a/dipper/sources/KEGG.py
+++ b/dipper/sources/KEGG.py
@@ -152,7 +152,7 @@ class KEGG(OMIMSource):
 
         self._process_diseases(limit)
         self._process_genes(limit)
-        self._process_omim2gene(limit)
+        #self._process_omim2gene(limit)
         self._process_omim2disease(limit)
         #self._process_kegg_disease2gene(limit)
         self._process_pathway_ko(limit)

--- a/dipper/sources/MMRRC.py
+++ b/dipper/sources/MMRRC.py
@@ -229,8 +229,8 @@ class MMRRC(Source):
                     try:
                         [curie, localid] = mgi_gene_id.split(':')
                     except ValueError as verror:
-                        LOG.warning("Problem parsing mgi_gene_id {} from file {}: {}".
-                            format(mgi_gene_id, fname, verror))
+                        LOG.warning("Problem parsing mgi_gene_id %s from file %s: %s",
+                                    mgi_gene_id, fname, verror)
                     if curie not in ['MGI', 'NCBIGene']:
                         LOG.info("MGI Gene id not recognized: %s", mgi_gene_id)
                     self.strain_hash[strain_id]['genes'].add(mgi_gene_id)
@@ -309,7 +309,7 @@ class MMRRC(Source):
                 genes = h['genes']
                 vl_set = set()
                 # make variant loci for each gene
-                if len(variants) > 0:
+                if variants:
                     for var in variants:
                         vl_id = var.strip()
                         vl_symbol = self.id_label_hash[vl_id]
@@ -350,7 +350,7 @@ class MMRRC(Source):
                     model.addIndividualToGraph(
                         vslc_id, vslc_label,
                         self.globaltt['variant single locus complement'])
-                if len(vslc_list) > 0:
+                if vslc_list:
                     if len(vslc_list) > 1:
                         gvc_id = '-'.join(vslc_list)
                         gvc_id = re.sub(r'_|:', '', gvc_id)


### PR DESCRIPTION
This PR fixes problems causing AnimaQTLdb, Flybase, and MMRRC ingests to fail.

* AnimalQTLdb:
   * added column info to be consistent with how other ingests do row checking while ingesting files
   * fixed ingest to recover when bad data is encountered in _process_qtls_genetic_location() - two records from source contain extra columns

* Flybase:
    * fixed error while parsing fbrf_pmid_pmcid_doi_fb_.*.tsv.gz, caused by encoding not being set correctly (latin-1)

* MMRRC:
fixed two problems in parsing mmrrc_catalog_data.csv:
   * one record from source contains extra columns, causing ingest to fail because of ValueError
   * header was being parsed incorrectly, causing first two records to be silently ignored, because of change in format of header upstream at MMRRC