### PR TITLE
Fix parse error causing MGI ingest to fail

### DIFF
--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -1726,7 +1726,9 @@ SELECT  r._relationship_key as rel_key,
                         if not re.match(r'MMRRC:', strain_id):
                             strain_id = 'MMRRC:'+strain_id
                     elif logicaldb_key == '37':  # EMMA
-                        strain_id = re.sub(r'EM:', 'EMMA:', accid)
+                        # replace EM: prefix with EMMA:, or for accid's
+                        # with bare digits (e.g. 06335) prepend 'EMMA:'
+                        strain_id = re.sub(r'^(EM:)*', 'EMMA:', accid)
                     elif logicaldb_key == '90':  # APB
                         strain_id = 'APB:' + accid  # Check
                     elif logicaldb_key == '40':  # ORNL


### PR DESCRIPTION
Error results from this line in prb_strain_acc_view:
`06335		37	78775	1`
The code in MGI.py assumes the first column here is going to have a 'EM:' prefix, which it usually does. This 'EM:' prefix is substituted with ['EMMA:'](https://github.com/monarch-initiative/dipper/blob/e185cf24ecb5d2aa111bf19fa8822fc20444ed35/dipper/sources/MGI.py#L1729) and used as a strain_id later on.

The ingest fails when this first column above is used as strain_id, which is used as subject in a triple later on [here](https://github.com/monarch-initiative/dipper/blob/e185cf24ecb5d2aa111bf19fa8822fc20444ed35/dipper/sources/MGI.py#L1762), causing this:

```
ERROR:dipper.utils.CurieUtil:Not a properly formed curie: "06335"
ERROR:dipper.graph.RDFGraph:couldn't make URI for 06335
Traceback (most recent call last):
  File "dipper-etl.py", line 280, in <module>
    main()
  File "dipper-etl.py", line 252, in main
    mysource.parse(args.limit)
  File "/var/lib/jenkins/workspace/dipper-pipeline/dipper/sources/MGI.py", line 272, in parse
    self._process_prb_strain_acc_view(limit)
  File "/var/lib/jenkins/workspace/dipper-pipeline/dipper/sources/MGI.py", line 1766, in _process_prb_strain_acc_view
    model.addIndividualToGraph(strain_id, None, tax_id)
  File "/var/lib/jenkins/workspace/dipper-pipeline/dipper/models/Model.py", line 80, in addIndividualToGraph
    ind_id, self.globaltt['type'], ind_type, object_is_literal=False)
  File "/var/lib/jenkins/workspace/dipper-pipeline/dipper/graph/RDFGraph.py", line 82, in addTriple
    self._getnode(obj)))
  File "/var/lib/jenkins/workspace/dipper-pipeline/venv/lib/python3.6/site-packages/rdflib/graph.py", line 1351, in add
    _assertnode(s,p,o)
  File "/var/lib/jenkins/workspace/dipper-pipeline/venv/lib/python3.6/site-packages/rdflib/graph.py", line 1945, in _assertnode
    'Term %s must be an rdflib term' % (t,)
AssertionError: Term None must be an rdflib term
script returned exit code 1
```

Fix is to alter the regex slightly so this item has the prefix 'EMMA:' like the other equivalent items. 