### PR TITLE
OMIM caching

### DIFF
--- a/dipper/sources/OMIMSource.py
+++ b/dipper/sources/OMIMSource.py
@@ -6,14 +6,9 @@ from dipper import config
 
 LOG = logging.getLogger(__name__)
 
-
-# omimftp key EXPIRES
-# get a new one here: https://omim.org/help/api
-
 OMIMURL = 'https://data.omim.org/downloads/'
-OMIMFTP = OMIMURL + config.get_config()['keys']['omim']
-USER_AGENT = "The Monarch Initiative (https://monarchinitiative.org/; " \
-             "info@monarchinitiative.org)"
+MONARCHURL = 'https://archive.monarchinitiative.org/'
+MONARCHIVE = MONARCHURL + config.get_config()['keys']['monarchive']
 
 
 class OMIMSource(Source):
@@ -33,9 +28,8 @@ class OMIMSource(Source):
     mimfiles = {  # do not conflict with subclasses 'files' dict
         'mimtitles': {
             'file': 'mimTitles.txt',
-            'url':  OMIMFTP + '/mimTitles.txt',
+            'url':   MONARCHIVE + '/mimTitles.txt',
             'clean': OMIMURL,
-            'headers': {'User-Agent': USER_AGENT},
             'columns': [  # expected
                 'Prefix',
                 'Mim Number',

--- a/dipper/sources/OMIMSource.py
+++ b/dipper/sources/OMIMSource.py
@@ -28,7 +28,7 @@ class OMIMSource(Source):
     mimfiles = {  # do not conflict with subclasses 'files' dict
         'mimtitles': {
             'file': 'mimTitles.txt',
-            'url':   MONARCHIVE + '/mimTitles.txt',
+            'url': MONARCHIVE + '/mimTitles.txt',
             'clean': OMIMURL,
             'columns': [  # expected
                 'Prefix',


### PR DESCRIPTION
Several weeks ago Monarch  offended OMIM by pulling a file too many times in too short a period and they implemented a quota on how many times we will be served.
To avoid running afoul of their quota in the future we now pull the file once cache it locally and ingests pull from that cache. 