### PR TITLE
Makefile tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ test_translationtable:
 	@ $(TEST) tests/test_trtable.py
 	@ echo "----------------------------------------------------------------------"
 	@ echo "Is the _entire_ $(GTT) file ordered by ontology curie?"
-	@ sort -k2,2 -k3,3n -t ':' --stable --check $(GTT)
+	@ LC_ALL=en_US.UTF-8 sort -k2,2 -k3,3n -t ':' --stable --check $(GTT)
 	@ echo "----------------------------------------------------------------------"
 	@ echo "Orphan labels in dipper/source/Ingest.py  w.r.t. $(GTT)?"
 	@ scripts/check_labels_v_gtt.sh

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ test_translationtable:
 	@ echo "python unit test for duplicate keys and invertablility in global tt"
 	@ $(TEST) tests/test_trtable.py
 	@ echo "----------------------------------------------------------------------"
-	@ echo -e "Is _entire_ $(GTT) file ordered by ontology curie?"
+	@ echo "Is the _entire_ $(GTT) file ordered by ontology curie?"
 	@ sort -k2,2 -k3,3n -t ':' --stable --check $(GTT)
 	@ echo "----------------------------------------------------------------------"
 	@ echo "Orphan labels in dipper/source/Ingest.py  w.r.t. $(GTT)?"


### PR DESCRIPTION
My foray into how mac's sort was not encouraging.
I can elicit the mac behaviour with `LC_ALL=C`   for a case sensitive sort
So I am attempting to alter macs the behaviour  with `LC_ALL=en_US.UTF-8 `  
which is an explicit case insensitive sort.

If it works great, 
if not  well at least I tried 
but time is short for problems neither I nor our production environment have.  