### PR TITLE
Move ontology declarations to summary level IRI, which is stable

### DIFF
--- a/dipper/models/Dataset.py
+++ b/dipper/models/Dataset.py
@@ -281,6 +281,10 @@ class Dataset:
                              self.curie_map.get(""))  # eval's to MI.org
         self.graph.addTriple(self.version_level_curie, self.globaltt['isVersionOf'],
                              self.summary_level_curie, object_is_literal=False)
+        self.graph.addTriple(self.version_level_curie,
+                             self.globaltt['distribution'],
+                             self.distribution_level_turtle_curie,
+                             object_is_literal=False)
 
     def _set_distribution_level_triples(self):
         self.model.addType(self.distribution_level_turtle_curie,
@@ -490,8 +494,8 @@ class Dataset:
 
         """
         model = Model(self.graph)
-        model.addOntologyDeclaration(self.distribution_level_turtle_curie)
-        model.addOWLVersionIRI(self.distribution_level_turtle_curie,
+        model.addOntologyDeclaration(self.summary_level_curie)
+        model.addOWLVersionIRI(self.summary_level_curie,
                                self.version_level_curie)
         if version_info is not None:
             model.addOWLVersionInfo(self.distribution_level_turtle_curie,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -226,6 +226,25 @@ class DatasetTestCase(unittest.TestCase):
             (self.summary_level_IRI, self.iri_logo, URIRef(self.iri_returned_logo))))
         self.assertTrue(len(triples) == 1, "missing summary level source logo triple")
 
+    def test_summary_level_ontology_type_declaration(self):
+        triples = list(self.dataset.graph.triples(
+            (self.summary_level_IRI,
+             self.iri_rdf_type,
+             self.iri_owl_ontology)))
+        self.assertTrue(len(triples) == 1,
+                        "missing distribution level owl ontology type triple")
+
+    def test_summary_level_owl_version_iri(self):
+        triples = list(self.dataset.graph.triples(
+            (self.summary_level_IRI,
+            self.iri_owl_version_iri,
+            None)))
+        self.assertTrue(len(triples) == 1,
+                        "missing distribution level owl version iri triple")
+        self.assertEqual(triples[0][2],
+                         URIRef(self.version_level_IRI),
+                         "owl version iri triple has the wrong object")
+
     #
     # Test version level resource triples:
     #
@@ -303,6 +322,13 @@ class DatasetTestCase(unittest.TestCase):
         triples = list(self.dataset.graph.triples(
             (self.version_level_IRI, self.iri_is_version_of, self.summary_level_IRI)))
         self.assertTrue(len(triples) == 1, "missing version level isVersionOf triple")
+
+    def test_version_level_distribution(self):
+        triples = list(self.dataset.graph.triples(
+            (self.version_level_IRI,
+             self.iri_distribution,
+             self.distribution_level_IRI_ttl)))
+        self.assertTrue(len(triples) == 1, "missing version level distribution triple")
 
     #
     # test distribution level triples
@@ -427,25 +453,6 @@ class DatasetTestCase(unittest.TestCase):
              URIRef(self.license_url_default))))
         self.assertTrue(len(triples) == 1,
                         "distribution level default license triple not set")
-
-    def test_distribution_level_ontology_type_declaration(self):
-        triples = list(self.dataset.graph.triples(
-            (self.distribution_level_IRI_ttl,
-             self.iri_rdf_type,
-             self.iri_owl_ontology)))
-        self.assertTrue(len(triples) == 1,
-                        "missing distribution level owl ontology type triple")
-
-    def test_distribution_level_owl_version_iri(self):
-        triples = list(self.dataset.graph.triples(
-            (self.distribution_level_IRI_ttl,
-            self.iri_owl_version_iri,
-            None)))
-        self.assertTrue(len(triples) == 1,
-                        "missing distribution level owl version iri triple")
-        self.assertEqual(triples[0][2],
-                         URIRef(self.version_level_IRI),
-                         "owl version iri triple has the wrong object")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Per discussion with Kent, having the ontology declaration attached to a stable IRI is helpful for Scigraph reasons. 

I'm also adding a missing triple required by the HCLS spec, which was somehow missing