### PR TITLE
Fix for GO ingest

### DIFF
--- a/dipper/sources/GeneOntology.py
+++ b/dipper/sources/GeneOntology.py
@@ -26,6 +26,8 @@ GOGA = 'http://current.geneontology.org/annotations'
 FTPEBI = 'ftp://ftp.uniprot.org/pub/databases/'     # best for North America
 UPCRKB = 'uniprot/current_release/knowledgebase/'
 
+# large entries in field 7 of ZFIN require this:
+csv.field_size_limit(sys.maxsize)
 
 class GeneOntology(Source):
     """


### PR DESCRIPTION
In `zfin.gaf.gz`, very large entry in field 7 evidently breaks `csv`'s ability to parse with default field size limit. Increasing this fixes it