### PR TITLE
Fix monarch owl build step in Dipper pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,7 +170,7 @@ pipeline {
                         dir('./create-monarch-owl') {deleteDir()}
                         dir('./create-monarch-owl') {
                             sh """
-                                wget http://build.berkeleybop.org/job/owltools/lastSuccessfulBuild/artifact/OWLTools-Runner/target/owltools
+                                wget http://release.geneontology.org/2019-10-07/bin/owltools
 
                                 chmod +x owltools
 


### PR DESCRIPTION
Updated broken link to owltools to point to a working link for (and known version) of owltools. This link is broken for the time being because of power outages here at LBL. @kltm advised that the link we were using, even when it is working, is probably not a good choice, as it is likely to be volatile. 

(We could alternatively point to http://current.geneontology.org/bin/owltools, but we'd obviously be linking to an unknown version of owltools.)

Also, we possibly could/should be using robot instead of owltools here
