### PR TITLE
Panther: refactor for efficency and correctness

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,6 @@
     Consider linting before running
     see:  https://jenkins.io/doc/book/pipeline/development/
 
-    ssh -p 8675 localhost declarative-linter < ./Jenkinsfile
-
 **/
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
         DATA_DEST = "${env.RELEASE ? '/var/www/data/dev/' : '/var/www/data/experimental/'}"
 
         /* human, mouse, zebrafish, fly, worm */
-        COMMON_TAXON = 9606,10090,7955,7227,6239
+        COMMON_TAXON = "9606,10090,7955,7227,6239"
         /* 10116 is rat and might be included if found relevent where it is now missing */
 
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,9 +36,9 @@ pipeline {
         // https://issues.jenkins-ci.org/browse/JENKINS-47881
         DATA_DEST = "${env.RELEASE ? '/var/www/data/dev/' : '/var/www/data/experimental/'}"
 
-        # human, mouse, zebrafish, fly, worm
+        /* human, mouse, zebrafish, fly, worm */
         COMMON_TAXON = 9606,10090,7955,7227,6239
-        # 10116 is rat and might be included if found relevent where it is now missing
+        /* 10116 is rat and might be included if found relevent where it is now missing */
 
     }
 

--- a/dipper/sources/Panther.py
+++ b/dipper/sources/Panther.py
@@ -290,47 +290,33 @@ class Panther(Source):
         # which keeps the penultimate & ultimite tokens (aka last two)
 
         if species == 'CAEEL':
-            if geneid[0:13] == 'EnsemblGenome:':
-                geneid = 'WormBase' + geneid[12:]
-            elif geneid[0:4] == 'Gene:':
-                geneid = 'WormBase' + geneid[3:]
-        elif species == 'DROME':
-            if re.match(r'(EnsemblGenome):\w+\.\d+', geneid):
-                geneid = re.sub(
-                    r'(?:EnsemblGenome):(\w+\.\d+)', r'FlyBase:\1', geneid)
+            if geneid[0:14] == 'EnsemblGenome:':
+                geneid = 'WormBase:' + geneid[14:]
+            elif geneid[:9] == 'Gene:CELE':  # Gene:CELE --> WormBase: (old cosmid ids)
+                geneid = 'WormBase:' + geneid[9:]
+            elif geneid[0:5] == 'Gene:':
+                geneid = 'WormBase' + geneid[5:]
 
-        # rewrite Ensembl --> ENSEMBL    ... why? they don't
-        # geneid = re.sub(r'^Ensembl:', 'ENSEMBL:', geneid)
-        if geneid[:8] == 'Ensembl:':
-            geneid = 'ENSEMBL:' + geneid[8:]
-        # rewrite GeneID --> NCBIGene
-        # geneid = re.sub(r'GeneID', 'NCBIGene', geneid)
-        elif geneid[:7] == 'GeneID:':
-            geneid = 'NCBIGene:' + geneid[7:]
-        # rewrite Gene:Dmel --> FlyBase
-        # geneid = re.sub(r'Gene:Dmel_', 'FlyBase:', geneid)
-        elif geneid[:10] == 'Gene:Dmel_':
-            geneid = 'FlyBase:' + geneid[10:]
-        # rewrite Gene:CG --> FlyBase:CG
-        # geneid = re.sub(r'Gene:CG', 'FlyBase:CG', geneid)
-        elif geneid[:7] == 'Gene:CG':
-            geneid = 'FlyBase:' + geneid[5:]
-        # rewrite ENSEMBLGenome:FBgn --> FlyBase:FBgn
-        # geneid = re.sub(r'EnsemblGenome:FBgn', 'FlyBase:FBgn', geneid)
-        elif geneid[:18] == 'EnsemblGenome:FBgn':
-            geneid = 'FlyBase:' + geneid[14:]
-        # rewrite Gene:<ensembl ids> --> ENSEMBL:<id>
-        # geneid = re.sub(r'Gene:ENS', 'ENSEMBL:ENS', geneid)
-        elif geneid[:8] == 'Gene:ENS':
-            geneid = 'ENSEMBL:' + geneid[5:]
-        # rewrite Gene:<Xenbase ids> --> Xenbase:<id>
-        # geneid = re.sub(r'Gene:Xenbase:', 'Xenbase:', geneid)
-        elif geneid[:12] == 'Gene:Xenbase':
-            geneid = 'Xenbase:' + geneid[12:]
-        # rewrite Gene:CELE --> WormBase  these are old-school cosmid identifier
-        # geneid = re.sub(r'^Gene:CELE', 'WormBase:', geneid)
-        elif geneid[:9] == 'Gene:CELE':
-            geneid = 'WormBase:' + geneid[9:]
+        elif species == 'DROME':
+            if geneid[0:14] == 'EnsemblGenome:':
+                geneid = 'FlyBase:' + geneid[14:]
+            elif geneid[:10] == 'Gene:Dmel_':   #  Gene:Dmel_ --> FlyBase:
+                geneid = 'FlyBase:' + geneid[10:]
+            elif geneid[:7] == 'Gene:CG':
+                geneid = 'FlyBase:' + geneid[5:]  #  Gene:CG --> FlyBase:CG
+
+        else:
+
+            if geneid[:8] == 'Ensembl:':         #  Ensembl --> ENSEMBL   (why?)
+                geneid = 'ENSEMBL:' + geneid[8:]
+            elif geneid[:7] == 'GeneID:':        #  GeneID: --> NCBIGene:
+                geneid = 'NCBIGene:' + geneid[7:]
+            elif geneid[:8] == 'Gene:ENS':       #  Gene:<ensembl ids> --> ENSEMBL:<id>
+                geneid = 'ENSEMBL:' + geneid[5:]
+
+            elif geneid[:12] == 'Gene:Xenbase':  # Gene:<Xenbase ids> --> Xenbase:<id>
+                geneid = 'Xenbase:' + geneid[12:]
+
 
         pfx = geneid.split(':')[0]
         if pfx is None or pfx not in self.curie_map:

--- a/resources/animalqtldb/README
+++ b/resources/animalqtldb/README
@@ -1,5 +1,5 @@
 
-the below is superceeded.
+the below is superceeded  as of 2019 Dec.
 the files are now generated in the ncbigene section of DipperCache Makefile
 
 


### PR DESCRIPTION
I had wanted to make an incremental improvement in longest running timed ingest
but tests runs indicate that although more orthologs are processed in the same time  
many more orthologs are being found to process. 
spot checks (on sample run) indicate the new orthologs should have been there all along. 
missed genes seem to preferentially involve Ensembl identifiers. 

I expect this ingest will experience a wash for time (~16 hours) and output 300% of previous (including 100% of previous).

Will also note the additional genes/orthology/relations are not of a different kind.
Just a haphazard  sprinkle of more of the same.

## Update after full run
6 hours 17 minutes  runtime and virtually identical output (9k fewer out of 52.7M)
things lost include URI incorrectly expressed as literals.
things gained (all 22 of them) are limited to Dataset metadata.

Plausible explanation; running on data sets truncated to the first few tens of thousands of rows incurred higher fixed cost, but the new version does a better of extracting.

wornbase may be over represented in the 9k statements dropped
reworked  gene cleaning logic,  should be improved

-------------------------------------------------------------------------------------

Rework the Jenkins file a bit. 
find a way of validating it before use.

    

