### PR TITLE
Set created on and data release version in metadata dynamically

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
             returnStdout: true
         ).trim()
 
-        DATA_RELEASE_VERSION = "202001"
+        DATA_RELEASE_VERSION = 'date +%Y%m'
         DIPPERCACHE = 'https://archive.monarchinitiative.org/DipperCache'
 
         MONARCH_DATA_FS = 'monarch-ttl-prod'

--- a/dipper/models/Dataset.py
+++ b/dipper/models/Dataset.py
@@ -272,7 +272,8 @@ class Dataset:
             self.model.addDescription(self.version_level_curie,
                                       self.ingest_description)
         self.graph.addTriple(self.version_level_curie, self.globaltt['Date Created'],
-                             Literal(self.data_release_version, datatype=XSD.date))
+                             Literal(datetime.today().strftime("%Y%m%d"),
+                                     datatype=XSD.date))
         self.graph.addTriple(self.version_level_curie, self.globaltt['version'],
                              Literal(self.data_release_version, datatype=XSD.date))
         self.graph.addTriple(self.version_level_curie, self.globaltt['creator'],
@@ -305,7 +306,8 @@ class Dataset:
                              Literal(self.data_release_version, datatype=XSD.date))
         self.graph.addTriple(self.distribution_level_turtle_curie,
                              self.globaltt['Date Created'],
-                             Literal(self.data_release_version, datatype=XSD.date))
+                             Literal(datetime.today().strftime("%Y%m%d"),
+                                     datatype=XSD.date))
         self.graph.addTriple(self.distribution_level_turtle_curie,
                              self.globaltt['creator'],
                              self.curie_map.get(""))  # eval's to MI.org

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -275,7 +275,8 @@ class DatasetTestCase(unittest.TestCase):
         self.assertTrue(len(triples) == 1,
                         "didn't get exactly 1 version level created triple")
         self.assertEqual(triples[0][2],
-                         Literal(self.data_release_version, datatype=XSD.date),
+                         Literal(datetime.today().strftime("%Y%m%d"),
+                                 datatype=XSD.date),
                          "version level created triple has the wrong timestamp")
 
     def test_version_level_version_default(self):
@@ -370,7 +371,7 @@ class DatasetTestCase(unittest.TestCase):
             (self.distribution_level_IRI_ttl, self.iri_created, None)))
         self.assertTrue(len(triples) == 1,
                         "didn't get exactly 1 version level type created triple")
-        self.assertEqual(triples[0][2], Literal(self.data_release_version,
+        self.assertEqual(triples[0][2], Literal(datetime.today().strftime("%Y%m%d"),
                                                 datatype=XSD.date))
 
     def test_distribution_level_version(self):


### PR DESCRIPTION
Two minor changes: 
- set `dcterms:created` using actual date instead of DATA_RELEASE_VERSION
- set DATA_RELEASE_VERSION in Jenkins using call to `date`