### PR TITLE
prefix  'schemaorg:' to 'schema:' 

### DIFF
--- a/dipper/curie_map.yaml
+++ b/dipper/curie_map.yaml
@@ -17,7 +17,7 @@
 'owl': 'http://www.w3.org/2002/07/owl#'                             # Web Ontology Language
 'skos': 'https://www.w3.org/TR/skos-reference/#'                    # Simple Knowledge Organization System
 # 'Annotation': 'http://www.w3.org/ns/oa#Annotation'                # Web annotation
-'schemaorg': 'http://schema.org/'                                   # Schema.org "provides schemas for structured data on the Internet"
+'schema': 'http://schema.org/'                                      # Schema.org "provides schemas for structured data on the Internet"
 
 # dataset description
 'dcat': 'http://www.w3.org/ns/dcat#'                                # Data Catalog Vocabulary

--- a/dipper/models/Dataset.py
+++ b/dipper/models/Dataset.py
@@ -47,7 +47,7 @@ class Dataset:
      [summary level resource] - dct:description -> description (literal)
                                                 (use docstring from Source class)
      [summary level resource] - dcterms:source -> [source web page, e.g. omim.org]
-     [summary level resource] - schemaorg:logo -> [source logo IRI]
+     [summary level resource] - schema:logo -> [source logo IRI]
      [summary level resource] - dct:publisher -> monarchinitiative.org
         n.b: about summary level resource triples:
         -- HCLS spec says we "should" link to our logo and web page, but I'm not,
@@ -249,9 +249,7 @@ class Dataset:
                              True)
         self.model.addTriple(self.summary_level_curie, self.globaltt['Publisher'],
                              self.curie_map.get(""))
-        self.model.addTriple(self.summary_level_curie,
-                             "schemaorg:logo",
-                             self.ingest_logo)
+        self.model.addTriple(self.summary_level_curie, "schema:logo", self.ingest_logo)
         self.graph.addTriple(self.summary_level_curie, self.globaltt['identifier'],
                              self.summary_level_curie)
         if self.ingest_url is not None:

--- a/dipper/sources/GeneOntology.py
+++ b/dipper/sources/GeneOntology.py
@@ -145,14 +145,15 @@ class GeneOntology(Source):
         #   'file': 'gene_association.goa_uniprot.gz',
         #   'url': FTPEBI + 'GO/goa/UNIPROT/gene_association.goa_uniprot.gz'},
 
-        'go-references': {
-            'file': 'GO.references',
-            # Quoth the header of this file: "This file is DEPRECATED.
-            # Please see go-refs.json relative to this location"
-            # (http://current.geneontology.org/metadata/go-refs.json)
-            'url': 'http://www.geneontology.org/doc/GO.references'
-        },
+        # 'go-references': {  # does not seem to be used
+        #    'file': 'GO.references',
+        #   # Quoth the header of this file: "This file is DEPRECATED.
+        #    # Please see go-refs.json relative to this location"
+        #    # (http://current.geneontology.org/metadata/go-refs.json)
+        #    'url': 'http://www.geneontology.org/doc/GO.references'
+        # },
         'id-map': {  # 8.5GB mapping file takes hours to DL ... maps UniProt to Ensembl
+            # replace w/ Ensembl rdf?
             'file': 'idmapping_selected.tab.gz',
             'url':  FTPEBI + UPCRKB + 'idmapping/idmapping_selected.tab.gz',
             # ftp://ftp.uniprot.org
@@ -376,7 +377,7 @@ class GeneOntology(Source):
                 for ref in refs:
                     ref = ref.strip()
                     if ref != '':
-                        prefix = ref.split(':')[0]  # sidestep 'MGI:MGI:'
+                        prefix = ref.split(':')[-2]  # sidestep 'MGI:MGI:'
                         if prefix in self.localtt:
                             prefix = self.localtt[prefix]
                         ref = ':'.join((prefix, ref.split(':')[-1]))
@@ -453,7 +454,7 @@ class GeneOntology(Source):
                         for ref in refs:
                             ref = ref.strip()
                             if ref != '':
-                                prefix = ref.split(':')[0]
+                                prefix = ref.split(':')[-2]
                                 if prefix in self.localtt:
                                     prefix = self.localtt[prefix]
                                 ref = ':'.join((prefix, ref.split(':')[-1]))

--- a/tests/test_dataset.gv
+++ b/tests/test_dataset.gv
@@ -25,7 +25,7 @@ digraph metadata_model {
     summary_level -> summary_level_title [label="dct:title"]
     summary_level -> summary_level_description [label="dct:description"]
     summary_level -> source_web_page [label="dcterms:source"]
-    summary_level -> source_logo_IRI [label="schemaorg:logo"]
+    summary_level -> source_logo_IRI [label="schema:logo"]
     summary_level -> "monarchinitiative.org" [label="dct:publisher"]
 
     // version level triples:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -55,7 +55,7 @@ class DatasetTestCase(unittest.TestCase):
         cls.base_pav = 'http://purl.org/pav/'
         cls.base_rdf = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
         cls.base_rdfs = 'http://www.w3.org/2000/01/rdf-schema#'
-        cls.base_schemaorg = 'http://schema.org/'
+        cls.base_schema = 'http://schema.org/'
         cls.base_void = 'http://rdfs.org/ns/void#'
         cls.base_owl = 'http://www.w3.org/2002/07/owl#'
         cls.base_logo_url = "https://github.com/monarch-initiative/monarch-ui/blob/master/public/img/sources/"
@@ -94,7 +94,7 @@ class DatasetTestCase(unittest.TestCase):
         cls.iri_description = URIRef(cls.base_dc + "description")
         cls.iri_publisher = URIRef(cls.base_dcterms + "Publisher")
         cls.iri_source = URIRef(cls.base_dcterms + "source")
-        cls.iri_logo = URIRef(cls.base_schemaorg + "logo")
+        cls.iri_logo = URIRef(cls.base_schema + "logo")
         cls.iri_mi_org = URIRef("https://monarchinitiative.org/")
         cls.iri_created = URIRef(cls.base_dcterms + "created")
         cls.iri_version = URIRef(cls.base_pav + "version")

--- a/translationtable/generated/curiemap_prefix.txt
+++ b/translationtable/generated/curiemap_prefix.txt
@@ -194,7 +194,7 @@
 "rainbow_troutQTL"
 "rdf"
 "rdfs"
-"schemaorg"
+"schema"
 "sheepQTL"
 "skos"
 "vfb"


### PR DESCRIPTION
change our chosen prefix to match existing usage 
see:
http://prefix.cc/schema


 extra: go edits 
 - comments out fetching a file the ingest does not seem to use
 - the file warns it is depreciated
 - it's replacement is on DipperCache
