### PR TITLE
Jenkins ERROR log reductions

### DIFF
--- a/dipper/curie_map.yaml
+++ b/dipper/curie_map.yaml
@@ -170,6 +170,9 @@
 'rainbow_troutQTL': 'https://www.animalgenome.org/cgi-bin/QTLdb/OM/qdetails?QTL_ID='
 'sheepQTL': 'https://www.animalgenome.org/cgi-bin/QTLdb/OA/qdetails?QTL_ID='
 
+'BGD': 'http://bovinegenome.org/genepages/btau40/genes/'                # The Bovine Genome Database (no direct link)
+#                                                                       # 'http://128.206.116.13:8080/bovinemine/report.do?id='
+
 'ClinVar': 'http://www.ncbi.nlm.nih.gov/clinvar/'                       # Clinical Variation in Human
 'ClinVarVariant': 'http://www.ncbi.nlm.nih.gov/clinvar/variation/'      # ClinVar cooked variants
 'ClinVarSubmitters': 'http://www.ncbi.nlm.nih.gov/clinvar/submitters/'  # ClinVar raw variants

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -135,109 +135,110 @@ class AnimalQTLdb(Source):
             'file': 'QTL_Btau_4.6.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_Btau_4.6.gff.txt.gz',
             'curie': 'cattleQTL',
-            'columns': gff_columns
+            'columns': gff_columns,
         },
         'cattle_cm': {
             'file': 'cattle_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/cattle_QTLdata.txt',
             'curie': 'cattleQTL',
-            'columns': qtl_columns
+            'columns': qtl_columns,
         },
         'chicken_bp': {
             'file': 'QTL_GG_4.0.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_GG_4.0.gff.txt.gz',
             'curie': 'chickenQTL',
-            'columns': gff_columns
+            'columns': gff_columns,
         },
         'chicken_cm': {
             'file': 'chicken_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/chicken_QTLdata.txt',
             'curie': 'chickenQTL',
-            'columns': qtl_columns
+            'columns': qtl_columns,
         },
         'pig_bp': {
             'file': 'QTL_SS_10.2.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_SS_10.2.gff.txt.gz',
             'curie': 'pigQTL',
-            'columns': gff_columns
+            'columns': gff_columns,
         },
         'pig_cm': {
             'file': 'pig_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/pig_QTLdata.txt',
             'curie': 'pigQTL',
-            'columns': qtl_columns
+            'columns': qtl_columns,
         },
         'sheep_bp': {
             'file': 'QTL_OAR_3.1.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_OAR_3.1.gff.txt.gz',
             'curie': 'sheepQTL',
-            'columns': gff_columns
+            'columns': gff_columns,
         },
         'sheep_cm': {
             'file': 'sheep_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/sheep_QTLdata.txt',
             'curie': 'sheepQTL',
-            'columns': qtl_columns
+            'columns': qtl_columns,
         },
         'horse_bp': {
             'file': 'QTL_EquCab2.0.gff.txt.gz',
             'url': AQDL + '/tmp/QTL_EquCab2.0.gff.txt.gz',
             'curie': 'horseQTL',
-            'columns': gff_columns
+            'columns': gff_columns,
         },
         'horse_cm': {
             'file': 'horse_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/horse_QTLdata.txt',
             'curie': 'horseQTL',
-            'columns': qtl_columns
+            'columns': qtl_columns,
         },
         'rainbow_trout_cm': {
             'file': 'rainbow_trout_QTLdata.txt',
             'url': AQDL + '/export/KSUI8GFHOT6/rainbow_trout_QTLdata.txt',
             'curie': 'rainbow_troutQTL',
-            'columns': qtl_columns
+            'columns': qtl_columns,
         },
 
         #                  Gene_info from NCBI
         # to reasure TEC that when we see an integer
         # it is a gene identifier from NCBI for the species
-        # misses will not block, but they will squawk, (the last three are homemade)
+        # misses will not block, but they will squawk,
+        # The last three are homemade, (in DipperCache)
 
         # pig  # "Sus scrofa"  # NCBITaxon:9823
         'Sus_scrofa_info': {
             'file': 'Sus_scrofa.gene_info.gz',
             'url': GENEINFO + '/Mammalia/Sus_scrofa.gene_info.gz',
-            'columns': gene_info_columns
+            'columns': gene_info_columns,
         },
         # cattle  # "Bos taurus"      # NCBITaxon:9913
         'Bos_taurus_info': {
             'file': 'Bos_taurus.gene_info.gz',
             'url': GENEINFO + '/Mammalia/Bos_taurus.gene_info.gz',
-            'columns': gene_info_columns
+            'columns': gene_info_columns,
         },
         # chicken  # "Gallus gallus"  # NCBITaxon:9031
         'Gallus_gallus_info': {
             'file': 'Gallus_gallus.gene_info.gz',
             'url': Source.DIPPERCACHE + '/Gallus_gallus.gene_info.gz',
-            'columns': gene_info_columns
+            'columns': gene_info_columns,
         },
         # horse  # "Equus caballus"  # NCBITaxon:9796
         'Equus_caballus_info': {
             'file': 'Equus_caballus.gene_info.gz',
             'url': Source.DIPPERCACHE + '/Equus_caballus.gene_info.gz',
-            'columns': gene_info_columns
+            'columns': gene_info_columns,
         },
         # sheep  # "Ovis aries"  # NCBITaxon:9940
         'Ovis_aries_info': {
             'file': 'Ovis_aries.gene_info.gz',
             'url': Source.DIPPERCACHE + '/Ovis_aries.gene_info.gz',
-            'columns': gene_info_columns
+            'columns': gene_info_columns,
         },
         # rainbow trout  # "Oncorhynchus mykiss"  # NCBITaxon:8022
         'Oncorhynchus_mykiss_info': {
             'file': 'Oncorhynchus_mykiss.gene_info.gz',
             'url': Source.DIPPERCACHE + '/Oncorhynchus_mykiss.gene_info.gz',
-            'columns': gene_info_columns
+            'columns': gene_info_columns,
         },
         ########################################
         # TODO add rainbow_trout_bp when available
@@ -245,7 +246,7 @@ class AnimalQTLdb(Source):
         'trait_mappings': {
             'file': 'trait_mappings.csv',
             'url': AQDL + '/export/trait_mappings.csv',
-            'columns': trait_mapping_columns
+            'columns': trait_mapping_columns,
         },
     }
 
@@ -321,9 +322,10 @@ class AnimalQTLdb(Source):
                     if re.match('^#', row[0][0]):
                         continue
                     if len(row) != len(col):
-                        LOG.warning("Problem parsing in %s row %s\n"
-                                    "got %s cols but expected %s",
-                                    gene_info_file, row, len(row), len(col))
+                        LOG.warning(
+                            "Problem parsing in %s row %s\n"
+                            "got %s cols but expected %s",
+                            gene_info_file, row, len(row), len(col))
                     self.gene_info.append(row[col.index('GeneID')])
             LOG.info(
                 'Gene Info for %s has %i entries', common_name, len(self.gene_info))
@@ -382,27 +384,23 @@ class AnimalQTLdb(Source):
             graph = self.testgraph
         else:
             graph = self.graph
-        line_counter = 0
         geno = Genotype(graph)
         model = Model(graph)
         eco_id = self.globaltt['quantitative trait analysis evidence']
-
         taxon_curie = 'NCBITaxon:' + txid
 
         LOG.info("Processing genetic location for %s from %s", taxon_curie, raw)
         with open(raw, 'r', encoding="iso-8859-1") as csvfile:
-            filereader = csv.reader(csvfile, delimiter='\t', quotechar='\"')
+            reader = csv.reader(csvfile, delimiter='\t', quotechar='\"')
             # no header in these files, so no header checking
-
             col = self.files[src_key]['columns']
-
-            for row in filereader:
-                line_counter += 1
+            for row in reader:
 
                 if len(row) != len(self.qtl_columns):
-                    LOG.warning("Problem parsing in %s row %s\n"
-                                "got %s cols but expected %s",
-                                raw, row, len(row), len(col))
+                    LOG.warning(
+                        "Problem parsing %s line %i containing: \n%s\n"
+                        "got %i cols but expected %i",
+                        raw, reader.line_num, row, len(row), len(col))
                     continue
                 else:
                     qtl_id = row[col.index('qtl_id')].strip()
@@ -614,7 +612,7 @@ class AnimalQTLdb(Source):
                     assoc.add_association_to_graph()
 
                 # off by one - the following actually gives us (limit + 1) records
-                if not self.test_mode and limit is not None and line_counter > limit:
+                if not self.test_mode and limit is not None and reader.line_num > limit:
                     break
 
         LOG.info("Done with QTL genetic info")

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -1218,7 +1218,7 @@ SELECT  r._relationship_key as rel_key,
                 pub_id = None
                 if logicaldb_key == '29':  # pubmed
                     pub_id = 'PMID:' + accid
-                elif logicaldb_key == '1' and prefixpart[:3] == 'MGI:':
+                elif logicaldb_key == '1' and prefixpart[:4] == 'MGI:':
                     # don't get the J numbers,
                     # because we dont' need to make the equiv to itself.
                     pub_id = accid

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -213,7 +213,7 @@ class MGI(PostgreSQLSource):
             query_fh = open(os.path.join(
                 os.path.dirname(__file__), query_map['query']), 'r')
             query = query_fh.read()
-            force = False
+            # force = False
             # if 'Force' in query_map:   # unused
             #     force = query_map['Force']
             self.fetch_query_from_pgdb(
@@ -1164,8 +1164,9 @@ SELECT  r._relationship_key as rel_key,
         LOG.info('populating pub id hash')
         raw = '/'.join((self.rawdir, 'bib_acc_view'))
         col = [
-            'accid', 'prefixpart', 'numericpart', 'object_key', 'logical_db',
-            'logicaldb_key']
+            'accid', 'prefixpart', 'numericpart', '_object_key', 'logical_db',
+            '_logicaldb_key']
+
         with open(raw, 'r', encoding="utf8") as csvfile:
             filereader = csv.reader(csvfile, delimiter='\t', quotechar='\"')
             header = next(filereader)
@@ -1176,9 +1177,9 @@ SELECT  r._relationship_key as rel_key,
                 accid = row[col.index('accid')]
                 prefixpart = row[col.index('prefixpart')]
                 # 'numericpart'
-                object_key = int(row[col.index('object_key')])
+                object_key = int(row[col.index('_object_key')])  # likely unstable
                 # logical_db = row[col.index('logical_db')]
-                # logicaldb_key = row[col.index('logicaldb_key')]
+                # logicaldb_key = row[col.index('_logicaldb_key')]
 
                 if self.test_mode and object_key not in self.test_keys.get('pub'):
                     continue
@@ -1205,9 +1206,9 @@ SELECT  r._relationship_key as rel_key,
                 accid = row[col.index('accid')]
                 prefixpart = row[col.index('prefixpart')]
                 # 'numericpart'
-                object_key = int(row[col.index('object_key')])
+                object_key = int(row[col.index('_object_key')])
                 logical_db = row[col.index('logical_db')]
-                logicaldb_key = row[col.index('logicaldb_key')]
+                logicaldb_key = row[col.index('_logicaldb_key')]
 
                 if self.test_mode is True:
                     if int(object_key) not in self.test_keys.get('pub'):
@@ -1217,7 +1218,7 @@ SELECT  r._relationship_key as rel_key,
                 pub_id = None
                 if logicaldb_key == '29':  # pubmed
                     pub_id = 'PMID:' + accid
-                elif logicaldb_key == '1' and re.match(r'MGI:', prefixpart):
+                elif logicaldb_key == '1' and prefixpart[:3] == 'MGI:':
                     # don't get the J numbers,
                     # because we dont' need to make the equiv to itself.
                     pub_id = accid

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -1880,9 +1880,10 @@ SELECT  r._relationship_key as rel_key,
         raw = '/'.join((self.rawdir, 'mgi_relationship_transgene_genes'))
         geno = Genotype(graph)
         col = [
-            'rel_key', 'allele_key', 'allele_id', 'allele_label', 'category_key',
-            'category_name', 'property_key', 'property_name', 'gene_num'
+            'rel_key', 'object_1', 'allele_id', 'allele_label', 'category_key',
+            'category_name', 'property_key', 'property_name', 'property_value'
         ]
+
         with open(raw, 'r', encoding="utf8") as csvfile:
             filereader = csv.reader(csvfile, delimiter='\t', quotechar='\"')
             header = next(filereader)
@@ -1890,14 +1891,14 @@ SELECT  r._relationship_key as rel_key,
                 LOG.error('expected columns:  %s\n\tBut got:\n%s', col, header)
             for row in filereader:
                 # rel_key,
-                allele_key = int(row[col.index('allele_key')])
+                allele_key = int(row[col.index('object_1')])
                 allele_id = row[col.index('allele_id')]
                 # allele_label,
                 # category_key,
                 # category_name,
                 # property_key,
                 # property_name,
-                gene_num = int(row[col.index('gene_num')])
+                gene_num = int(row[col.index('property_value')])
 
                 if self.test_mode and allele_key not in self.test_keys.get('allele')\
                         and gene_num not in self.test_ids:

--- a/dipper/sources/MMRRC.py
+++ b/dipper/sources/MMRRC.py
@@ -144,13 +144,11 @@ class MMRRC(Source):
             reader = csv.reader(csvfile, delimiter=',', quotechar='\"')
             # First line is header not date/version info. This changed recently,
             # apparently as of Sep 2019. Also, 3rd line is no longer blank.
-            header = next(reader)
+            row = [x.strip() for x in next(reader)]  # messy messy
             col = self.files['catalog']['columns']
-            if col != header:
-                LOG.error(
-                    '%s\nExpected Headers:\t%s\nReceived Headers:\t%s\n',
-                    src_key, col, header)
-                LOG.info(set(col) - set(header))
+            strain_missing_allele = []  # to count the ones w/insufficent info
+            if not self.check_fileheader(col, row):
+                pass
 
             for row in reader:
                 strain_id = row[col.index('STRAIN/STOCK_ID')].strip()
@@ -287,11 +285,19 @@ class MMRRC(Source):
                             assoc.add_source(p)
                         assoc.add_association_to_graph()
                     else:
-                        LOG.info("Phenotypes and no allele for %s", strain_id)
+                        # too chatty here. report aggregate
+                        # LOG.info("Phenotypes and no allele for %s", strain_id)
+                        strain_missing_allele.append(strain_id)
 
                 if not self.test_mode and (
                         limit is not None and reader.line_num > limit):
                     break
+
+            # report misses
+            if strain_missing_allele:
+                LOG.info(
+                    "Phenotypes and no allele for %i strains",
+                    len(strain_missing_allele))
 
             # now that we've collected all of the variant information, build it
             # we don't know their zygosities
@@ -317,7 +323,7 @@ class MMRRC(Source):
                     # it's just anonymous variants in some gene
                     for gene in genes:
                         vl_id = '_:' + re.sub(r':', '', gene) + '-VL'
-                        vl_symbol = self.id_label_hash[gene]+'<?>'
+                        vl_symbol = self.id_label_hash[gene] + '<?>'
                         self.id_label_hash[vl_id] = vl_symbol
                         geno.addAllele(
                             vl_id, vl_symbol, self.globaltt['variant_locus'])
@@ -330,7 +336,7 @@ class MMRRC(Source):
                 vslc_list = []
                 for vl in vl_list:
                     # for unknown zygosity
-                    vslc_id = re.sub(r'^_', '', vl)+'U'
+                    vslc_id = re.sub(r'^_', '', vl) + 'U'
                     vslc_id = re.sub(r':', '', vslc_id)
                     vslc_id = '_:' + vslc_id
                     vslc_label = self.id_label_hash[vl] + '/?'
@@ -346,7 +352,7 @@ class MMRRC(Source):
                     if len(vslc_list) > 1:
                         gvc_id = '-'.join(vslc_list)
                         gvc_id = re.sub(r'_|:', '', gvc_id)
-                        gvc_id = '_:'+gvc_id
+                        gvc_id = '_:' + gvc_id
                         gvc_label = '; '.join(self.id_label_hash[v] for v in vslc_list)
                         model.addIndividualToGraph(
                             gvc_id, gvc_label,

--- a/dipper/sources/NCBIGene.py
+++ b/dipper/sources/NCBIGene.py
@@ -102,6 +102,15 @@ class NCBIGene(OMIMSource):
         'clique_leader': '../../resources/clique_leader.yaml'
     }
 
+    informal_species = {
+        'NCBITaxon:9913': 'cattle',
+        'NCBITaxon:9031': 'chicken',
+        'NCBITaxon:9823': 'pig',
+        'NCBITaxon:9940': 'sheep',
+        'NCBITaxon:9796': 'horse',
+        'NCBITaxon:8022': 'rainbow_trout',
+    }
+
     def __init__(
             self,
             graph_type,
@@ -274,8 +283,12 @@ class NCBIGene(OMIMSource):
                     model.addSynonym(gene_id, name)
                 if synonyms != '-':
                     for syn in synonyms.split('|'):
+                        syn = syn.strip()
+                        if syn[:11] == 'AnimalQTLdb:' and \
+                                tax_id in self.informal_species:
+                            syn = self.informal_species[tax_id] + 'QTL:' + syn[11:]
                         model.addSynonym(
-                            gene_id, syn.strip(), model.globaltt['has_related_synonym'])
+                            gene_id, syn, model.globaltt['has_related_synonym'])
                 if other_designations != '-':
                     for syn in other_designations.split('|'):
                         model.addSynonym(

--- a/dipper/sources/NCBIGene.py
+++ b/dipper/sources/NCBIGene.py
@@ -284,9 +284,9 @@ class NCBIGene(OMIMSource):
                 if synonyms != '-':
                     for syn in synonyms.split('|'):
                         syn = syn.strip()
-                        if syn[:11] == 'AnimalQTLdb:' and \
+                        if syn[:12] == 'AnimalQTLdb:' and \
                                 tax_id in self.informal_species:
-                            syn = self.informal_species[tax_id] + 'QTL:' + syn[11:]
+                            syn = self.informal_species[tax_id] + 'QTL:' + syn[12:]
                         model.addSynonym(
                             gene_id, syn, model.globaltt['has_related_synonym'])
                 if other_designations != '-':

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -795,7 +795,7 @@ class Source:
         exp = set(expected)
         got = set(received)
         if expected != received:
-            LOG.error('\nExpected header: %s\nRecieved header: %s', expected, received)
+            LOG.error('\nExpected header:\n %s\nRecieved header:\n %s', expected, received)
 
             # pass reordering and adding new columns (after protesting)
             # hard fail on missing expected columns (temper with mandatory cols?)

--- a/translationtable/generated/curiemap_prefix.txt
+++ b/translationtable/generated/curiemap_prefix.txt
@@ -5,6 +5,7 @@
 "AspGD"
 "AspGD_REF"
 "BFO"
+"BGD"
 "BIOGRID"
 "BNODE"
 "BT"


### PR DESCRIPTION
With Jenkins not failing loudly as often we can turn our attention to the stifled sobs coming from behind the wall of logs.

Here we make a pass at addressing the (down to) 100K ERROR messages dipper emits
with an eye first to reduce the greatest volume of less than tragic pronouncements.

Top of the list is "I can't find this curie prefix" which may be fixed by looking harder or
adding in what is missing.

There are other  errors having to do with column header name discrepancies
which can run from stray trailing spaces  to new underscore decorations to scarily different names which will need to be checked carefully after being run.

While looking for the sources of these reported errors there is the inevitable clean up as you go edits. 
 
 