### PR TITLE
GO  rdf subjects as valid curies

### DIFF
--- a/dipper/sources/FlyBase.py
+++ b/dipper/sources/FlyBase.py
@@ -463,7 +463,7 @@ class FlyBase(PostgreSQLSource):
         species_map = self._species_to_ncbi_tax()
         src_key = 'allele_gene'
         raw = '/'.join((self.rawdir, self.files[src_key]['file']))
-        LOG.info("Getting list of transgenic alleles")
+        LOG.info("Getting list of transgenic alleles from %s", raw)
 
         col = self.files[src_key]['columns']
 

--- a/dipper/sources/GeneOntology.py
+++ b/dipper/sources/GeneOntology.py
@@ -435,8 +435,11 @@ class GeneOntology(Source):
                             LOG.warning(
                                 "Skipping  %s from or with %s", uniprotid, itm)
                             continue
-                        itm = re.sub(r'MGI\:MGI\:', 'MGI:', itm)
-                        itm = re.sub(r'WB:', 'WormBase:', itm)
+                        # sanity check/conversion on go curie prefix
+                        (pfx, lclid) = itm.split(':')[-2:]  # last prefix wins
+                        if pfx in self.localtt:
+                            pfx =  self.localtt[pfx]
+                        itm = ':'.join((pfx, lclid))
 
                         # for worms and fish, they might give a RNAi or MORPH
                         # in these cases make a reagent-targeted gene

--- a/dipper/utils/CurieUtil.py
+++ b/dipper/utils/CurieUtil.py
@@ -33,13 +33,13 @@ class CurieUtil(object):
         prefix = self.get_curie_prefix(uri)
         if prefix is not None:
             key = self.curie_map[prefix]
-            return '%s:%s' % (prefix, uri[len(key):len(uri)])
+            return f'{prefix}:{uri[len(key):len(uri)]}'
         return None
 
     def get_curie_prefix(self, uri):
         ''' Return the CURIE's prefix:'''
         for key, value in self.uri_map.items():
-            if uri.startswith(key):
+            if uri.startswith(key):  # no... need the longest match not the first match
                 return value
         return None
 


### PR DESCRIPTION
new curie prefixes happened, 
either via fresh data ... or unblocking an existing pathway.
either way existing curie fixing mechanism seem to work,

the CurieUtil edit maybe premature but also seems not to break anything.
I am not a fan of gratuitously adopting new behaviour because it is shiny 
but stuck my nose in there (CU) because it is a hotspot in the panther ingest
so any bit helps.
That said addressing the added comment in an efficient manner 
is apt to swamp any benefit from the new string building format. 
 