### PR TITLE
MGISlim,  reduce expected "errors"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -455,18 +455,18 @@ pipeline {
                         '''
                     }
                 }
-                stage("ETL MGI Slim") {
+                stage("ETL MGISlim") {
                     when {
                         anyOf {
                             expression { env.RUN_ALL != null }
-                            expression { env.MGI_SLIM != null }
+                            expression { env.MGISLIM != null }
                         }
                     }
                     steps {
                         sh '''
-                            SOURCE=mgi-slim
+                            SOURCE=mgislim
                             $DIPPER --sources $SOURCE
-                            scp ./out/mgi_slim.ttl ./out/mgi_slim_dataset.ttl monarch@$MONARCH_DATA_FS:$DATA_DEST
+                            scp ./out/mgislim.ttl ./out/mgislim_dataset.ttl monarch@$MONARCH_DATA_FS:$DATA_DEST
                         '''
                     }
                 }
@@ -599,7 +599,7 @@ pipeline {
                         '''
                     }
                 }
-                stage("ETL ZFIN Slim") {
+                stage("ETL ZFINSlim") {
                     when {
                         anyOf {
                             expression { env.RUN_ALL != null }

--- a/dipper-etl.py
+++ b/dipper-etl.py
@@ -49,7 +49,7 @@ def main():
         'go': 'GeneOntology',
         'reactome': 'Reactome',
         'udp': 'UDP',
-        'mgi-slim': 'MGISlim',
+        'mgislim': 'MGISlim',
         'zfinslim': 'ZFINSlim',
         'bgee': 'Bgee',
         'mydrug': 'MyDrug',

--- a/dipper/sources/MGISlim.py
+++ b/dipper/sources/MGISlim.py
@@ -25,7 +25,7 @@ class MGISlim(Source):
             graph_type=graph_type,
             are_bnodes_skized=are_bnodes_skolemized,
             data_release_version=data_release_version,
-            name='mgi_slim',
+            name='mgislim',
             ingest_description='Simplified Mouse Genome Informatics',
             ingest_url='http://www.mousemine.org/mousemine/service',
             ingest_logo="source-mgi.png",

--- a/translationtable/mgi.yaml
+++ b/translationtable/mgi.yaml
@@ -191,7 +191,7 @@
 "M. spretus or M. m. domesticus": "Mus"   # '862507' -> SubGenus not Genus
 "M. m. molossinus (Anjo, Japan)": "Mus musculus molossinus"
 "M. m. castaneus or M. m. musculus": "Mus musculus"
-"laboratory mouse and M. m. castaneus and M. m. domesticus poschiavinus": "Mus musculus"
+"laboratory mouse and M. m. castaneus and M. m. domesticus poschiavinus": "Mus"
 "M. spretus (Spain)": "Mus spretus"
 "M. m. molossinus (Japan)": "Mus musculus molossinus"
 "M. lepidoides": "Mus lepidoides"
@@ -227,10 +227,10 @@
 "M. m. domesticus": "Mus musculus"
 "M. m. castaneus and laboratory mouse": "Mus musculus"
 "M. m. domesticus (Australia)": "Mus musculus"
-"laboratory mouse and M. m. domesticus and M. m. molossinus": "Mus musculus"
+"laboratory mouse and M. m. domesticus and M. m. molossinus": "Mus"
 "M. m. domesticus (brevirostris) (Morocco)": "Mus musculus"
 "Mus musculus/domesticus": "Mus musculus"
-"laboratory mouse and M. spretus and M. m. musculus": "Mus musculus"
+"laboratory mouse and M. spretus and M. m. musculus": "Mus"
 "M. m. molossinus": "Mus musculus molossinus"
 "M. hortulanus": "Mus spicilegus"  # synonymous with Mus spicilegus
 "M. dunni": "Mus terricolor"  # synonymous with Mus terricolor
@@ -265,7 +265,7 @@
 "M. saxicola": "Mus saxicola"
 "M. m. praetextus x M. m. musculus": "Mus musculus"
 "M. spretus and laboratory mouse": "Mus"   # '862507' -> SubGenus not Genus
-"laboratory mouse and M. m. castaneus and M. m. domesticus": "Mus musculus"
+"laboratory mouse and M. m. castaneus and M. m. domesticus": "Mus"
 "M. m. musculus (Bulgaria)": "Mus musculus"
 "M. booduga": "Mus booduga"
 "Not Specified and M. m. molossinus": "Mus musculus"
@@ -304,6 +304,14 @@
 "M. m. domesticus (Delaware, USA)": "Mus musculus"
 "M. m. domesticus and M. m. musculus": "Mus musculus"
 "M. m. castaneus and M. m. domesticus": "Mus musculus musculus x M. m. castaneus"
+"M. m. musculus (Senkvice, Slovak Republic>": "Mus musculus"
+"M. m. domesticus (Orcetto, Italy)": "Mus musculus"
+"M. m. domesticus (Lake Casitas, CA, USA)": "Mus musculus"
+"M. m. domesticus (Batumi, Adjara, Georgia)": "Mus musculus"
+"M. m. domesticus (Ann Arbor, MI, USA)": "Mus musculus"
+"laboratory mouse or M. m. castaneus": "Mus"
+"laboratory mouse and M. m. domesticus (Ohio, USA)": "Mus musculus"
 # more than two crosses; revert to Genus
 "laboratory mouse and M. m. musculus and M. spretus": "Mus"
 "M. m. castaneus and M. m. domesticus and M. m. molossinus": "Mus"
+"laboratory mouse and M. m. castaneus and M. m. domesticus and M. m. musculus (Prague)": "Mus"

--- a/translationtable/mgislim.yaml
+++ b/translationtable/mgislim.yaml
@@ -1,3 +1,3 @@
 ---
-# mgi_slim.yaml
+# mgislim.yaml
 "": ""  # example


### PR DESCRIPTION
MGISlim was inconsistently expressed with a hyphen and underscore where the ingest name convention is to use neither.

Source.resolve() has a use case where we only  expect to resolve as far as the local translation table where it should make less noise than when it is unexpected.

Since we expect some files to never be found in DipperCache mute the resulting 404s.

ICMP has many ways of expressing distinctions in mice origins we do not record.  
