### PR TITLE
MGI: use Mus for unknown taxa, ClinVar: replace MedGen prefix with UMLS

### DIFF
--- a/dipper/sources/ClinVar.py
+++ b/dipper/sources/ClinVar.py
@@ -874,7 +874,9 @@ def parse():
                         break
 
                     if rcv_disease_db is None and has_medgen_id:
-                        rcv_disease_db = 'MedGen'  # RCV_TraitXRef.get('DB')
+                        # use UMLS prefix instead of MedGen
+                        # see https://github.com/monarch-initiative/dipper/issues/874
+                        rcv_disease_db = 'UMLS'  # RCV_TraitXRef.get('DB')
                     if rcv_disease_id is None and has_medgen_id:
                         rcv_disease_id = medgen_id
 


### PR DESCRIPTION
Created a list of ambiguous/unknown taxon terms that conflict with the local translation table (that default these terms to sequence alteration).

In ClinVar, replacing MedGene prefix with UMLS to better merge this data with mondo, per @cmungall , we only use these Ids in the absence of an OMIM id.

Test run for MGI: https://ci.monarchinitiative.org/job/build-mgi/3/console
Test run for ClinVar: https://ci.monarchinitiative.org/job/build-clinvar/

Fixes #906
Fixes #874 