### PR TITLE
UDP  & misc

### DIFF
--- a/dipper/curie_map.yaml
+++ b/dipper/curie_map.yaml
@@ -61,7 +61,7 @@
 'LPT': 'http://purl.obolibrary.org/obo/LPT_'                        # Livestock Phenotypic Trait Ontology
 'MA': 'http://purl.obolibrary.org/obo/MA_'                          # Mouse Anatomy Ontology
 'MedGen': 'http://www.ncbi.nlm.nih.gov/medgen/'                     # Human Medical Genetics vocabulary
-'MESH': 'http://purl.obolibrary.org/obo/MESH_'                      # Medical Subject Headings (medical diseases, phenotypes, and drugs)
+'MESH': 'http://id.nlm.nih.gov/mesh/'                               # Medical Subject Headings (medical diseases, phenotypes, and drugs)
 'MP': 'http://purl.obolibrary.org/obo/MP_'                          # Mammalian Phenotype Ontology
 'MPATH': 'http://purl.obolibrary.org/obo/MPATH_'                    # Mammalian Pathology Ontology
 'NBO': 'http://purl.obolibrary.org/obo/NBO_'                        # NeuroBehavior Ontology

--- a/dipper/graph/RDFGraph.py
+++ b/dipper/graph/RDFGraph.py
@@ -58,7 +58,7 @@ class RDFGraph(DipperGraph, ConjunctiveGraph):
 
         if object_is_literal is True:
             if isinstance(obj, str):
-                obj = re.sub('[\t\n\r\f\v]+', ' ', obj)  # reduce any ws to a space
+                re.sub(r'[\t\n\r\f\v]+', ' ', obj)  # reduce any ws to a space
             if literal_type is not None and obj is not None and obj not in ("", " "):
                 literal_type_iri = self._getnode(literal_type)
 

--- a/dipper/graph/RDFGraph.py
+++ b/dipper/graph/RDFGraph.py
@@ -56,12 +56,16 @@ class RDFGraph(DipperGraph, ConjunctiveGraph):
                 object_is_literal = True
 
         if object_is_literal is True:
-            if literal_type is not None and obj is not None:
+            if isinstance(obj, str):
+                obj = re.sub('[\t\n\r\f\v]+', ' ', obj)  # reduce any ws to a space
+            if literal_type is not None and obj is not None and obj != "" and obj != " ":
                 literal_type_iri = self._getnode(literal_type)
+
                 self.add(
                     (self._getnode(subject_id), self._getnode(predicate_id),
                      Literal(obj, datatype=literal_type_iri)))
             elif obj is not None:
+                # could attempt to infer a type here but there is no use case
                 self.add((
                     self._getnode(subject_id), self._getnode(predicate_id),
                     Literal(obj)))
@@ -71,6 +75,7 @@ class RDFGraph(DipperGraph, ConjunctiveGraph):
                     subject_id, predicate_id)
                 # get a sense of where the None is comming from
                 # magic number here is "steps up the call stack"
+                # TODO there may be easier/ideomatic ways to do this now
                 for call in range(2, 0, -1):
                     LOG.warning(
                         '\t%sfrom: %s', '\t' * call, sys._getframe(call).f_code.co_name)

--- a/dipper/graph/RDFGraph.py
+++ b/dipper/graph/RDFGraph.py
@@ -26,8 +26,9 @@ class RDFGraph(DipperGraph, ConjunctiveGraph):
 
     # make global translation table available outside the ingest
     with open(
-            os.path.join(os.path.dirname(__file__),
-                         '../../translationtable/GLOBAL_TERMS.yaml')) as fhandle:
+        os.path.join(
+            os.path.dirname(__file__),
+            '../../translationtable/GLOBAL_TERMS.yaml')) as fhandle:
         globaltt = yaml.safe_load(fhandle)
         globaltcid = {v: k for k, v in globaltt.items()}
 
@@ -58,7 +59,7 @@ class RDFGraph(DipperGraph, ConjunctiveGraph):
         if object_is_literal is True:
             if isinstance(obj, str):
                 obj = re.sub('[\t\n\r\f\v]+', ' ', obj)  # reduce any ws to a space
-            if literal_type is not None and obj is not None and obj != "" and obj != " ":
+            if literal_type is not None and obj is not None and obj not in ("", " "):
                 literal_type_iri = self._getnode(literal_type)
 
                 self.add(

--- a/dipper/sources/GeneOntology.py
+++ b/dipper/sources/GeneOntology.py
@@ -483,7 +483,7 @@ class GeneOntology(Source):
             if uniprot_tot != 0:
                 uniprot_per = 100.0 * uniprot_hit / uniprot_tot
             LOG.info(
-                "Uniprot: %.2f%% of %i benefited from the 1/4 day id mapping download",
+                "Uniprot: %.2f%% of %i benefited from the mapping download",
                 uniprot_per, uniprot_tot)
 
     def get_uniprot_entrez_id_map(self):
@@ -493,7 +493,7 @@ class GeneOntology(Source):
         smallfile = '/'.join((self.rawdir, 'id_map_' + taxon_digest + '.yaml'))
         bigfile = '/'.join((self.rawdir, self.files[src_key]['file']))
 
-        # if processed smallfile exists and is newer than bigfile then use it instesd
+        # if processed smallfile exists and is newer than bigfile then use it instead
         if os.path.isfile(smallfile) and \
                 os.path.getctime(smallfile) > os.path.getctime(bigfile):
             LOG.info("Using the cheap mapping file %s", smallfile)

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -45,13 +45,13 @@ class Source:
             graph_type='rdf_graph',     # or streamed_graph
             are_bnodes_skized=False,    # typically True
             data_release_version=None,
-            name=None,                  # identifier; make an IRI for nquads
+            name=None,                  # identifier; make an URI for nquads
             ingest_title=None,
             ingest_url=None,
             ingest_logo=None,     # this should be the name of file on 'MonarchLogoRepo'
             ingest_description=None,
             license_url=None,           # only if it is _our_ lic
-            data_rights=None,           # external page that points to their current lic
+            data_rights=None,           # their page that points to their current lic
             file_handle=None,
     ):
 
@@ -117,7 +117,7 @@ class Source:
 
         elif graph_type == 'streamed_graph':
             # need to expand on export formats
-            dest_file = open(out_pth + '/' + name + '.nt', 'w')    # where is the close?
+            dest_file = open(out_pth + '/' + name + '.nt', 'w')   # where is the close?
             self.graph = StreamedGraph(are_bnodes_skized, dest_file)
             # leave test files as turtle (better human readibility)
         else:
@@ -172,11 +172,11 @@ class Source:
         """
         raise NotImplementedError
 
-    def write(self, fmt='turtle', stream=None, write_metadata_in_main_graph=True):
+    def write(self, fmt='turtle', stream=None, write_metadata_in_main_graph=False):
         """
         This convenience method will write out all of the graphs
-        associated with the source.
-        Right now these are hardcoded to be a single "graph"
+            associated with the source.
+        Right now these are hardcoded to be a single main "graph"
         and a "src_dataset.ttl" and a "src_test.ttl"
         If you do not supply stream='stdout'
         it will default write these to files.
@@ -297,7 +297,7 @@ class Source:
             LOG.info("Local File does NOT exist as %s", local)
             return True
 
-        # get remote file details
+        # get remote file details (if possible)
         if headers is None:
             headers = self._get_default_request_headers()
 

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -457,7 +457,7 @@ class Source:
                 LOG.error('NETWORK issue %s\n\tFor: %s', httpErr.read(), remoteurl)
                 return False  # allows re try (e.g. not found in Cache)
             except urllib.error.URLError as urlErr:
-                LOG.error('URLError %s\n\tFor: %s', urlErr.read(), remoteurl)
+                LOG.error('URLError %s\n\tFor: %s', urlErr, remoteurl)
                 return False
             if localfile is not None:
                 with open(localfile, 'wb') as binwrite:

--- a/dipper/sources/UDP.py
+++ b/dipper/sources/UDP.py
@@ -255,7 +255,7 @@ class UDP(Source):
         self._add_variant_gene_relationship(patient_var_map, gene_coordinate_map)
 
         for patient in patient_var_map:
-            patient_curie = ':{0}'.format(patient)
+            patient_curie = 'MONARCH:{0}'.format(patient)
             # make intrinsic genotype for each patient
             intrinsic_geno_bnode = self.make_id(
                 "{0}-intrinsic-genotype".format(patient), "_")
@@ -602,7 +602,7 @@ class UDP(Source):
         reader = csv.reader(file, delimiter="\t")
         for row in reader:
             (patient_id, hpo_curie, present) = row
-            patient_curie = ':{0}'.format(patient_id)
+            patient_curie = 'MONARCH:{0}'.format(patient_id)
             if patient_id == 'Patient':  # skip header
                 line_counter += 1
                 continue

--- a/scripts/ntriple2dot.awk
+++ b/scripts/ntriple2dot.awk
@@ -3,21 +3,21 @@
 #  Reduce the subject and object of RDF triples (ntriples format)
 #  down to their curie prefix (or literal object)
 #  Reduce predicates to the specific term identifier
-#  and the ontology namespace they are from. (curi prefix )
+#  and the ontology namespace they are from. (curie prefix )
 #  Express the subject and object as nodes with a directed edge
 #  labeled with the predicate in the graphviz dot format
 #  Include a tally of each combination of nodes and edge
 
 #  This may over generalize in some cases because I do not have
-#  a handy way to differentiate uri for subjects and objects
+#  a handy way to differentiate URI for subjects and objects
 #  which may belong to a "structural" ontology (t-box) as opposed to
-#  a data uri (a-box).
+#  a data URI (a-box).
 
 #  Post processing to augment predicate identifiers
 #  with their labels seems to improve usefulness.
 
 function usage(){
-    print "usage: ntriple2dot.awk prefix_baseurl.yaml rdf.nt > dot.gv"
+    print "usage: ntriple2dot.awk prefix_baseurl.yaml RDF.nt > dot.gv"
 }
 
 ##########################################################
@@ -68,7 +68,7 @@ function simplify(str){
     return str
 }
 
-# Replace IRI with CuriePrefix when possible
+# Replace URI with CuriePrefix when possible
 # Otherwise whinge and return a gv printable version of the original
 function contract(uri,  u){
     u = tokenize(uri)
@@ -83,7 +83,7 @@ function contract(uri,  u){
     #    # exit(1)  # while testing
     # }
 
-    # shorten till longest uri in curi map is found (or not)
+    # shorten till longest uri in curie map is found (or not)
     while(!(u in prefix) && index(u, SUBSEP)>0)
         u = detail(u)
 
@@ -121,8 +121,6 @@ function deoboify(curie,  a){
 BEGIN{
     # exceptions
     prefix["BNODE"]="BNODE"  # is a fixed point
-    prefix[tokenize("https://monarchinitiative.org/.well-known/genid")]="BNODE"
-    prefix[tokenize("https://archive.monarchinitiative.org/")]="MonarchArchive"
     ############################################################
     # not expected to be added to curie map
     # in HPOA
@@ -135,7 +133,7 @@ BEGIN{
     # https://raw.githubusercontent.com/monarch-initiative/dipper/master/dipper/curie_map.yaml
 
     # in mgi/impc
-    prefix[tokenize("https://www.mousephenotype.org/")]="IMPC"
+    prefix[tokenize("https://www.mousephenotype.org/")]="IMPC"  # TOO GENERAL
     # in IMPC (not httpS  --- hmm all three IRI exist)
     # note in curie_map IMPC is:
     # http://www.mousephenotype.org/data/genes/
@@ -145,36 +143,28 @@ BEGIN{
     # note in curie_map WormBase is
     # 'https://www.wormbase.org/get?name='
 
-    # various, transient?
-    prefix[tokenize("http://www.ncbi.nlm.nih.gov/gene/")]="NCBIGene"
-    prefix[tokenize("http://www.ncbi.nlm.nih.gov/genome/")]="NCBIGenome"
-    prefix[tokenize("http://www.ncbi.nlm.nih.gov/assembly?term=")]="NCBIAssembly"
-    # kegg
-    prefix[tokenize("http://www.genome.jp/kegg/pathway/map/")]="KEGG-img"
-    # in EOM
-    prefix[tokenize("https://elementsofmorphology.nih.gov/images/terms/")]="EOM_IMG"
-    # prefix[tokenize("http://elementsofmorphology.nih.gov/index.cgi?tid=")]="EOM"  # w/o httpS
+    # various, transient? (fewer now https or not is transparent)
+
 
     # playing with the idea of a LOCAL identifier
     # not the same as a bnode in that tools won't rewrite identifier
     # and their IRI are unroutable, i.e in same machine (or local net)
     # this is motivated in part by not wanting to publish
-    # urls to our own servers which go nowhere.
-    # prefix["https://127.0.0.1/.well-known/genid"]="BNODE"  # exists, phase out
+    # URLs to our own servers which go nowhere.
     # prefix["http://0.0.0.0/.well-known/genid"]="BNODE"     # prefer
     # prefix["http://0.0.0.0/"]="LCL"                              # ID halfway house
 
     # LCL's obvious down side is zero options for global collisions
-    # best you can do is go the uuid which is ugly, or
-    # belive your obscure but readable string _is_ a special snowflake
+    # best you can do is go the UUID which is ugly, or
+    # believe your obscure but readable string _is_ a special snowflake
 }
 
 # main loop
 # parse and stash the curie yaml file (first file)
-# YAML format is tic delimited word (the curi prefix)
-# a colon, whitespace
-# then a tic delimited url
-# convert the base url to a path in a multi-dimensional array
+# YAML format is tic delimited word (the curie prefix)
+# a colon, white space
+# then a tic delimited URL
+# convert the base URL to a path in a multi-dimensional array
 # (FNR == NR) && /^'[fht]\+tp[^']*'.*/ { # loosing some?
 (FNR == NR) && /^'.*/ {
     split($0, arr, "'")
@@ -267,8 +257,8 @@ END{
     print "}"
 
     ######################################################
-    # dump a summary of significant numbers of unresolved-curi uri  to stderr
-    # FNR gives at least half the number ot URI attempted to resolve for %s
+    # dump a summary of significant numbers of unresolved-curie uri  to stderr
+    # FNR gives at least half the number of URI attempted to resolve for %s
     # FILENAME gives filename we know where they were generated
     # have warn[uri] = count
     toofew = 3

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -88,7 +88,7 @@ class UDPTestCase(unittest.TestCase):
         mock_file = mock_open(mock=mock_data)
         udp._parse_patient_phenotypes(mock_file)
         triples = """
-        :patient_1 a foaf:Person ;
+        <https://monarchinitiative.org/MONARCH_patient_1> a foaf:Person ;
             rdfs:label "patient_1" ;
             RO:0002200 DOID:4,
               HP:000001 .
@@ -139,7 +139,7 @@ class UDPTestCase(unittest.TestCase):
         udp._parse_patient_variants(mock_file)
 
         triples = """
-        :patient_1 GENO:0000222 <https://monarchinitiative.org/.well-known/genid/ba5f377fc8c95d4a6d7a> .
+        <https://monarchinitiative.org/MONARCH_patient_1> GENO:0000222 <https://monarchinitiative.org/.well-known/genid/ba5f377fc8c95d4a6d7a> .
 
         <https://monarchinitiative.org/.well-known/genid/b41e8da0787b45e24c4f> a SO:0001059 ;
             rdfs:label "hg19chr1(CLK2):g.155230432G>A" ;


### PR DESCRIPTION
UDP (which I cannot run) got explicit MONARCH: curie prefix. Relying on default base prefix  results in a colon where we expect an underscore when processed with standard tools. (remember to fix tests)

Trying a run without duplicating metadata in the main graph, should eliminate whole classes of edge cases in post processing. 

Far fewer hardcoded curiemap  exceptions (for graphviz dot) theses days.

recently added try/except referenced non existent  .read() function 

spelling in comments type corrections