### PR TITLE
Revert Gallus gallus URL from Dipper Cache to NCBI URL

### DIFF
--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -224,8 +224,8 @@ class AnimalQTLdb(Source):
         },
         # horse  # "Equus caballus"  # NCBITaxon:9796
         'Equus_caballus_info': {
-            'file': 'Equus_caballus.gene_info.gz',
             # This file isn't on NCBI's ftp site, so need to use the cached URL instead.
+            'file': 'Equus_caballus.gene_info.gz',
             'url': Source.DIPPERCACHE + '/Equus_caballus.gene_info.gz',
             'columns': gene_info_columns,
         },

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -219,23 +219,29 @@ class AnimalQTLdb(Source):
         # chicken  # "Gallus gallus"  # NCBITaxon:9031
         'Gallus_gallus_info': {
             'file': 'Gallus_gallus.gene_info.gz',
-            'url': Source.DIPPERCACHE + '/Gallus_gallus.gene_info.gz',
+            'url': GENEINFO + '/Non-mammalian_vertebrates/Gallus_gallus.gene_info.gz',
             'columns': gene_info_columns,
         },
         # horse  # "Equus caballus"  # NCBITaxon:9796
         'Equus_caballus_info': {
             'file': 'Equus_caballus.gene_info.gz',
+            # This file seems to have disappeared from NCBI's ftp site, so need to
+            # use the cached URL instead.
             'url': Source.DIPPERCACHE + '/Equus_caballus.gene_info.gz',
             'columns': gene_info_columns,
         },
         # sheep  # "Ovis aries"  # NCBITaxon:9940
         'Ovis_aries_info': {
             'file': 'Ovis_aries.gene_info.gz',
+            # This file seems to have disappeared from NCBI's ftp site, so need to
+            # use the cached URL instead.
             'url': Source.DIPPERCACHE + '/Ovis_aries.gene_info.gz',
             'columns': gene_info_columns,
         },
         # rainbow trout  # "Oncorhynchus mykiss"  # NCBITaxon:8022
         'Oncorhynchus_mykiss_info': {
+            # This file seems to have disappeared from NCBI's ftp site, so need to
+            # use the cached URL instead.
             'file': 'Oncorhynchus_mykiss.gene_info.gz',
             'url': Source.DIPPERCACHE + '/Oncorhynchus_mykiss.gene_info.gz',
             'columns': gene_info_columns,

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -225,23 +225,20 @@ class AnimalQTLdb(Source):
         # horse  # "Equus caballus"  # NCBITaxon:9796
         'Equus_caballus_info': {
             'file': 'Equus_caballus.gene_info.gz',
-            # This file seems to have disappeared from NCBI's ftp site, so need to
-            # use the cached URL instead.
+            # This file isn't on NCBI's ftp site, so need to use the cached URL instead.
             'url': Source.DIPPERCACHE + '/Equus_caballus.gene_info.gz',
             'columns': gene_info_columns,
         },
         # sheep  # "Ovis aries"  # NCBITaxon:9940
         'Ovis_aries_info': {
+            # This file isn't on NCBI's ftp site, so need to use the cached URL instead.
             'file': 'Ovis_aries.gene_info.gz',
-            # This file seems to have disappeared from NCBI's ftp site, so need to
-            # use the cached URL instead.
             'url': Source.DIPPERCACHE + '/Ovis_aries.gene_info.gz',
             'columns': gene_info_columns,
         },
         # rainbow trout  # "Oncorhynchus mykiss"  # NCBITaxon:8022
         'Oncorhynchus_mykiss_info': {
-            # This file seems to have disappeared from NCBI's ftp site, so need to
-            # use the cached URL instead.
+            # This file isn't on NCBI's ftp site, so need to use the cached URL instead.
             'file': 'Oncorhynchus_mykiss.gene_info.gz',
             'url': Source.DIPPERCACHE + '/Oncorhynchus_mykiss.gene_info.gz',
             'columns': gene_info_columns,


### PR DESCRIPTION
The Gallus gallus file we're ingest still exists at NCBI, so it'd improve the metadata slightly to use this URL instead of the DipperCache URL.

Also added some comments in cases where we having to pull data files from DipperCache instead of NCBI

