### PR TITLE
OMIM api call delay

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@
     see:  https://jenkins.io/doc/book/pipeline/development/
     curl -X POST -H $(curl "127.0.0.1/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)") -F "jenkinsfile=<Jenkinsfile" 127.0.0.1/pipeline-model-converter/validate
 
-
 **/
 
 pipeline {
@@ -13,7 +12,6 @@ pipeline {
     /*triggers {
          Run every Monday at 5pm
          cron('H 17 * * 1')
-
     }*/
 
     environment {
@@ -97,7 +95,7 @@ pipeline {
                             steps {
                                 sh '''
                                     SOURCE=omim
-                                    $DIPPER --sources $SOURCE -q
+                                    $DIPPER --sources $SOURCE --quiet
                                     scp ./out/${SOURCE}.ttl ./out/${SOURCE}_dataset.ttl $MONARCH_DATA_DEST
                                 '''
                             }
@@ -202,7 +200,6 @@ pipeline {
                             sh '''
                                 wget --quiet --timestamping http://current.geneontology.org/bin/owltools
                                 chmod +x owltools
-
                                 java -Xmx100g -jar owltools http://purl.obolibrary.org/obo/upheno/monarch.owl --merge-import-closure --remove-disjoints --remove-equivalent-to-nothing-axioms -o monarch-merged.owl
 
                                 # Hack to resolve https://github.com/monarch-initiative/monarch-ontology/issues/16
@@ -283,7 +280,7 @@ pipeline {
                     steps {
                         sh '''
                             SOURCE=bgee
-                            $DIPPER --sources $SOURCE --limit 20 --taxon $COMMON_TAXON,10116 --version bgee_v14_0
+                            $DIPPER --sources $SOURCE --taxon $COMMON_TAXON,10116 --version bgee_v14_0 --limit 20
 
                             echo "check statement count and if well-formed?"
                             rapper -i turtle -c ./out/bgee.ttl
@@ -664,7 +661,7 @@ pipeline {
                     steps {
                         sh '''
                             SOURCE=sgd
-                            $DIPPER --sources $SOURCE --data_release_version $YYYYMM
+                            $DIPPER --sources $SOURCE
                             scp ./out/${SOURCE}.ttl ./out/${SOURCE}_dataset.ttl $MONARCH_DATA_DEST
                         '''
                     }

--- a/dipper/sources/OMIM.py
+++ b/dipper/sources/OMIM.py
@@ -2,8 +2,9 @@ import logging
 import re
 import json
 import urllib
+import time
 from urllib.error import HTTPError
-from datetime import date
+from datetime import date, datetime, timedelta
 
 from dipper.sources.OMIMSource import OMIMSource
 from dipper.sources.Source import USER_AGENT
@@ -203,6 +204,7 @@ class OMIM(OMIMSource):
             else:
                 maxit = len(omimids)
 
+            then = datetime.now()
             while acc < maxit:
                 end = min((maxit, acc + groupsize))
                 # iterate through the omim ids list,
@@ -223,6 +225,9 @@ class OMIM(OMIMSource):
 
                 url = OMIMAPI + urllib.parse.urlencode(omimparams)
 
+                while(datetime.now() - then) < timedelta(seconds=5):
+                    time.sleep(1)
+                then = datetime.now()
                 try:
                     req = urllib.request.urlopen(url)
                 except HTTPError as err:  # URLError?
@@ -232,6 +237,11 @@ class OMIM(OMIMSource):
                         msg = "API Key not valid"
                         raise HTTPError(url, err.code, msg, err.hdrs, err.fp)
                     LOG.error("Failed with: %s", str(error_msg))
+                    # dump what we have to see how far we got.
+                    with open(
+                            './raw/omim/_' + date.today().isoformat() + '.json_partial',
+                            'w') as writer:
+                        json.dump(reponse_batches, writer)
                     break
 
                 resp = req.read().decode()
@@ -241,7 +251,8 @@ class OMIM(OMIMSource):
 
             # snag a copy of all the batches
 
-            with open('./raw/omim/_'+date.today().isoformat()+'.json', 'w') as writer:
+            with open(
+                    './raw/omim/_' + date.today().isoformat() + '.json', 'w') as writer:
                 json.dump(reponse_batches, writer)
 
         LOG.info(

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -444,6 +444,7 @@ class Source:
         """
 
         response = None
+        result = False
         rmt_check = self.check_if_remote_is_newer(remoteurl, localfile, headers)
         if (is_dl_forced is True) or (localfile is None) or (
                 rmt_check is not None and rmt_check):
@@ -458,8 +459,8 @@ class Source:
                 return False  # allows re try (e.g. not found in Cache)
             except urllib.error.URLError as urlErr:
                 LOG.error('URLError %s\n\tFor: %s', urlErr, remoteurl)
-                return False
-            if localfile is not None:
+            result = response is not None
+            if localfile is not None and result:
                 with open(localfile, 'wb') as binwrite:
                     while True:
                         chunk = response.read(CHUNK)
@@ -487,7 +488,7 @@ class Source:
 
         else:
             LOG.info("Using existing file %s", localfile)
-        return True
+        return result
 
     # TODO: rephrase as mysql-dump-xml specific format
     def process_xml_table(self, elem, table_name, processing_function, limit):
@@ -806,8 +807,8 @@ class Source:
         exp = set(expected)
         got = set(received)
         if expected != received:
-            LOG.error('file resource: %s'
-                '\nExpected header:\n %s\nRecieved header:\n %s',
+            LOG.error(
+                'file resource: %s\nExpected header:\n %s\nRecieved header:\n %s',
                 src_key, expected, received)
 
             # pass reordering and adding new columns (after protesting)


### PR DESCRIPTION
increase the min time between api calls to avoid being throttled

Source.py  correct the logic when there is no file in dipper cache. was emitting inconsistant log message

Jenkind  minor cleanup, cerbose arg , remove redundant, consistant order 
