### PR TITLE
remove category from G2D

### DIFF
--- a/dipper/sources/OMIM.py
+++ b/dipper/sources/OMIM.py
@@ -695,9 +695,7 @@ class OMIM(OMIMSource):
             self.name,
             gene_id,
             disorder_id,
-            rel_id,
-            entity_category=blv.terms['Gene'],
-            phenotype_category=blv.terms['Disease']
+            rel_id
         )
 
         if phene_key is not None:


### PR DESCRIPTION
See #972, we should assign categories based on the omim type, not based on its position in a gene to disease association (which sometimes includes non diseases)