### PR TITLE
Orphanet via Model.py discourage CURIE/URI  objects as RDF literals  

### DIFF
--- a/dipper/curie_map.yaml
+++ b/dipper/curie_map.yaml
@@ -73,6 +73,9 @@
 'oboInOwl': 'http://www.geneontology.org/formats/oboInOwl#'         # obo-specific annotation properties, like synonym types
 # 'OMIA' was http://omia.angis.org.au/ IS https://omia.org/         # (see about helping to update original data)
 'OMIA': 'https://omia.org/OMIA'                                     # Online Mendelian Inheritance in Animals (disease/species)
+# LIDIA seems retired. so these are not resovable
+'LIDA': 'http://sydney.edu.au/vetscience/lida/dogs/search/disorder/' # Listing of Inherited Disorders in Animals (defunct?)
+                                                                     # Also: http://www.vetsci.usyd.edu.au/lida/
 'OMIM': 'http://omim.org/entry/'                                    # Online Mendelian Inheritance in Man (human disease and variants)
 'OMIMPS': 'http://www.omim.org/phenotypicSeries/'                   # Online Mendelian Inheritance in Man (phenotypes)
 'ORPHA': 'http://www.orpha.net/ORDO/Orphanet_'                      # Rare diseases and Orphan drugs
@@ -104,6 +107,7 @@
 'SEPIO': 'http://purl.obolibrary.org/obo/SEPIO_'                    # Scientific Evidence and Provenance Information Ontology
 'VIVO': 'http://vivoweb.org/ontology/core#'                         # ontology for representing scholarship
 'vfb': 'http://virtualflybrain.org/reports/'                        # Drosophila neuroanatomy
+
 
 # phenotype
 'EOM': 'https://elementsofmorphology.nih.gov/index.cgi?tid='         # Elements of Morphology phentoypes

--- a/dipper/models/Evidence.py
+++ b/dipper/models/Evidence.py
@@ -97,9 +97,10 @@ class Evidence:
             self.graph.addTriple(
                 evidence_line, self.globaltt['has_evidence_item'], measurement)
 
-            self.graph.addTriple(
-                measurement, self.globaltt['has_value'],  # 'has measurement value' ??
-                measurement_dict[measurement], True)
+            if measurement_dict[measurement] != '':
+                self.graph.addTriple(
+                    measurement, self.globaltt['has_value'],  # has measurement value ??
+                    measurement_dict[measurement], object_is_literal=True)
 
     def add_supporting_publication(
             self, evidence_line, publication, label=None, pub_type=None

--- a/dipper/models/Model.py
+++ b/dipper/models/Model.py
@@ -336,7 +336,7 @@ class Model():
         if synonym_type is None:
             synonym_type = self.globaltt['has_exact_synonym']
 
-        if synonym is not None:
+        if synonym is not None and synonym != '':
             self.graph.addTriple(
                 class_id,
                 synonym_type,
@@ -344,6 +344,7 @@ class Model():
                 object_is_literal=True,
                 subject_category=class_category
             )
+            # todo warn
 
     def addDefinition(self, class_id, definition, class_category=None):
         self.graph.addTriple(
@@ -392,6 +393,7 @@ class Model():
                 object_is_literal=True,
                 subject_category=subject_category
             )
+            # todo: warn; but only when we can say where it came from
 
     def addOntologyDeclaration(self, ontology_id):
         self.graph.addTriple(

--- a/dipper/models/Model.py
+++ b/dipper/models/Model.py
@@ -384,13 +384,14 @@ class Model():
         )
 
     def addDescription(self, subject_id, description, subject_category=None):
-        self.graph.addTriple(
-            subject_id,
-            self.globaltt['description'],
-            description.strip(),
-            object_is_literal=True,
-            subject_category=subject_category
-        )
+        if description is not None and description != '':
+            self.graph.addTriple(
+                subject_id,
+                self.globaltt['description'],
+                description.strip(),
+                object_is_literal=True,
+                subject_category=subject_category
+            )
 
     def addOntologyDeclaration(self, ontology_id):
         self.graph.addTriple(

--- a/dipper/models/Model.py
+++ b/dipper/models/Model.py
@@ -59,13 +59,15 @@ class Model():
         )
 
     def addLabel(self, subject_id, label, subject_category=None):
-        self.graph.addTriple(
-            subject_id,
-            self.globaltt['label'],
-            label,
-            object_is_literal=True,
-            subject_category=subject_category
-        )
+        if label != '':
+            self.graph.addTriple(
+                subject_id,
+                self.globaltt['label'],
+                label,
+                object_is_literal=True,
+                subject_category=subject_category
+            )
+        # warn
 
     def addClassToGraph(
             self,
@@ -102,7 +104,7 @@ class Model():
             self.globaltt['class'],
             subject_category=class_category
         )
-        if label is not None:
+        if label is not None and label != '':
             self.graph.addTriple(
                 class_id, self.globaltt['label'], label, object_is_literal=True
             )
@@ -114,7 +116,7 @@ class Model():
                 class_type,
                 object_category=class_type_category
             )
-        if description is not None:
+        if description is not None and description != '':
             self.graph.addTriple(
                 class_id,
                 self.globaltt['description'],
@@ -131,7 +133,7 @@ class Model():
             ind_category=None,
             ind_type_category=None
     ):
-        if label is not None:
+        if label is not None and label != '':
             self.graph.addTriple(
                 ind_id, self.globaltt['label'], label, object_is_literal=True
             )
@@ -151,7 +153,7 @@ class Model():
                 self.globaltt['named_individual'],
                 subject_category=ind_category
             )
-        if description is not None:
+        if description is not None and description != '':
             self.graph.addTriple(
                 ind_id,
                 self.globaltt['description'],
@@ -224,7 +226,7 @@ class Model():
         self.graph.addTriple(
             person_id, self.globaltt['type'], self.globaltt['person']
         )
-        if person_label is not None:
+        if person_label is not None and person_label != '':
             self.graph.addTriple(
                 person_id, self.globaltt['label'], person_label, object_is_literal=True
             )
@@ -367,9 +369,9 @@ class Model():
             class_id,
             self.globaltt['database_cross_reference'],
             xref_id,
+            object_is_literal=xref_as_literal,
             subject_category=class_category,
-            object_category=xref_category,
-            object_is_literal=xref_as_literal
+            object_category=xref_category
         )
 
     def addDepiction(self, subject_id, image_url):
@@ -385,11 +387,12 @@ class Model():
         )
 
     def addDescription(self, subject_id, description, subject_category=None):
+        description = description.strip()
         if description is not None and description != '':
             self.graph.addTriple(
                 subject_id,
                 self.globaltt['description'],
-                description.strip(),
+                description,
                 object_is_literal=True,
                 subject_category=subject_category
             )

--- a/dipper/models/Model.py
+++ b/dipper/models/Model.py
@@ -166,6 +166,7 @@ class Model():
             sub,
             self.globaltt['equivalent_class'],
             obj,
+            object_is_literal=False,
             subject_category=subject_category,
             object_category=object_category
         )
@@ -177,6 +178,7 @@ class Model():
             sub,
             self.globaltt['same_as'],
             obj,
+            object_is_literal=False,
             subject_category=subject_category,
             object_category=object_category
         )
@@ -214,6 +216,7 @@ class Model():
             class_id,
             self.globaltt['subclass_of'],
             bnode,
+            object_is_literal=False,
             subject_category=class_category
         )
 
@@ -311,6 +314,7 @@ class Model():
             child_id,
             self.globaltt['subclass_of'],
             parent_id,
+            object_is_literal=False,
             subject_category=child_category,
             object_category=parent_category
         )
@@ -421,7 +425,8 @@ class Model():
         self.graph.addTriple(
             node_id,
             self.globaltt['clique_leader'],
-            True, object_is_literal=True,
+            True,
+            object_is_literal=True,
             literal_type='xsd:boolean'
         )
 

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -514,6 +514,7 @@ class AnimalQTLdb(Source):
                     )
 
                 gene_id = gene_id.replace('uncharacterized ', '').strip()
+                gene_id = gene_id.strip(',')  # for "100157483,"  in pig_QTLdata.txt
                 if gene_id is not None and gene_id != '' and gene_id != '.'\
                         and re.fullmatch(r'[^ ]*', gene_id) is not None:
 

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -311,7 +311,7 @@ class AnimalQTLdb(Source):
             taxon_curie = self.globaltt[taxon_label]
             taxon_num = taxon_curie.split(':')[1]
             txid_num = taxon_num  # for now
-            taxon_word = taxon_label.replace(' ', '_')
+            taxon_word = taxon_label.strip().replace(' ', '_')
             src_key = taxon_word + '_info'
             gene_info_file = '/'.join((
                 self.rawdir, self.files[src_key]['file']))
@@ -323,7 +323,7 @@ class AnimalQTLdb(Source):
                 # headers
                 col = self.files[src_key]['columns']
                 for row in filereader:
-                    if re.match('^#', row[0][0]):
+                    if row[0][0] == '#':
                         continue
                     if len(row) != len(col):
                         LOG.warning(
@@ -384,7 +384,7 @@ class AnimalQTLdb(Source):
 
         """
         aql_curie = self.files[src_key]['curie']
-
+        common_name = common_name.strip()
         if self.test_mode:
             graph = self.testgraph
         else:
@@ -456,7 +456,7 @@ class AnimalQTLdb(Source):
 
                 # add a version of the chromosome which is defined as
                 # the genetic map
-                build_id = 'MONARCH:' + common_name.strip() + '-linkage'
+                build_id = 'MONARCH:' + common_name + '-linkage'
                 build_label = common_name + ' genetic map'
                 geno.addReferenceGenome(build_id, build_label, taxon_curie)
                 chrom_in_build_id = makeChromID(chromosome, build_id, 'MONARCH')

--- a/dipper/sources/EOM.py
+++ b/dipper/sources/EOM.py
@@ -259,11 +259,13 @@ class EOM(PostgreSQLSource):
                 # morphology_term_id has_related_synonym replaces (; delimited)
                 if replaces not in ['', synonyms]:
                     for syn in replaces.split(';'):
-                        model.addSynonym(
-                            morphology_term_id,
-                            syn.strip(),
-                            self.globaltt['has_related_synonym']
-                        )
+                        syn.strip()
+                        if syn != '':
+                            model.addSynonym(
+                                morphology_term_id,
+                                syn,
+                                self.globaltt['has_related_synonym']
+                            )
 
                 # <morphology_term_id> <foaf:page> morphology_term_url
                 if morphology_term_id is not None:

--- a/dipper/sources/FlyBase.py
+++ b/dipper/sources/FlyBase.py
@@ -182,7 +182,7 @@ class FlyBase(PostgreSQLSource):
             remotename = self._resolve_filename(self.files[src_key]['url'], ftp)
             if remotename != "":
                 # prepend ftp:// since this gets added to dataset rdf model
-                self.files[src_key]['url'] = "ftp://" + self.FLYFTP + remotename
+                self.files[src_key]['url'] = "ftp://" + self.FLYFTP + '/' + remotename
             else:  # cached vers?
                 self.files[src_key]['url'] = "/".join(
                     (self.DIPPERCACHE,  self.name, self.files[src_key]['file']))
@@ -304,8 +304,8 @@ class FlyBase(PostgreSQLSource):
                     # skip parsing for now
                     continue
                 else:
-                    raise ValueError("Unexpected phenotype type: {}".
-                                     format(pheno_type))
+                    raise ValueError(
+                        "Unexpected phenotype type: {}".format(pheno_type))
 
                 if pmid_id:
                     ref_curie = 'PMID:' + pmid_id
@@ -315,8 +315,9 @@ class FlyBase(PostgreSQLSource):
                     reference.setTitle(pub_title)
                     reference.addRefToGraph()
 
-                assoc = G2PAssoc(self.graph, self.name, allele_curie,
-                                 phenotype_curie, self.globaltt['has phenotype'])
+                assoc = G2PAssoc(
+                    self.graph, self.name, allele_curie,
+                    phenotype_curie, self.globaltt['has phenotype'])
                 assoc.add_source(ref_curie)
                 # Associations need to be disambiguated via their qualifiers
                 # see http://flybase.org/reports/FBal0207398 as an example
@@ -391,16 +392,19 @@ class FlyBase(PostgreSQLSource):
 
             self.check_fileheader(col, row)
 
-            next(reader)  # blank line
+            row = next(reader)  # blank line
 
             for row in reader:
                 row = [field.strip() for field in row]
-                prefix = row[col.index('abbreviation')]
-                tax_group = row[col.index('taxgroup')]
-                taxon = row[col.index('ncbi-taxon-id')]
+                prefix = row[col.index('abbreviation')].strip()
+                tax_group = row[col.index('taxgroup')].strip()
+                taxon = row[col.index('ncbi-taxon-id')].strip()
                 taxon = taxon.replace("taxon", "NCBITaxon")
 
-                species_map[prefix] = (tax_group, taxon)
+                #  ... tax_group is not None and tax_group != '' and \
+                if prefix is not None and prefix != '' and \
+                       taxon is not None and taxon != '':
+                    species_map[prefix] = (tax_group, taxon)
 
             # Add in hard coded prefixes
             for prefix, taxon in added_prefixes.items():
@@ -596,6 +600,22 @@ class FlyBase(PostgreSQLSource):
                             continue
                     except KeyError:
                         LOG.info("%s not in species prefix file", allele_prefix[0])
+                        note =  '''
+                            list of unincluded species prefixes include:
+                            Aace,Afun,Agos,Ahyp,Amil,Aobl,Apim,Apol,Aque,Asam,AspBV3L6,
+                            Avin,Baen,Bant,Bcen,Bdor,Beme,Besp,Bger,Blan,Bovi,Brsp,
+                            Bsp240B1,Bsub,Btab,Bter,Bxb1,BYV,CABYV,Cbeta,Ccaj,Cdif,
+                            Cfum,Cgri,Cint,Clsp,Cmar,Cnoc,Cpip,Cprd,Cqui,Crub,Csal,
+                            CsIV,D6,Dano,Dcaa,Dcol,Dcub,Ddun,DENV,Dflo,Dful,Dmas,Dnep,
+                            Drad,Ecab,Efae,Egra,Epos,Equa,EspSC22,Fmer,Gfas,Gint,Gmax,
+                            Gmor,Gthe,gypsy,Harm,hobo,HPV18,Hpyl,Hsod,HspTP009,Htur,
+                            Hver,Isca,jockey,Klac,Kpne,Lcup,Ldis,Lhem,Lmal,Lmon,Lser,
+                            Mani,Mbre,Mosp,Mper,Mril,NDV,Nlug,Npha,Nvec,Nvit,Oari,
+                            Obic,Osat,Paer,Pchi,PCV,Penelope,Pgur,Phum,Pime,Pmat,Pshi,
+                            Pvin,PVX,Pxyl,Rfla,Rhsp,Rpal,Rsph,Shel,Slit,Soce,Spou,
+                            Spyo,Tadh,TBSV,TCV,TEV,Tgeo,Tgon,Tmer,TNPV,TspX513,Tthe,
+                            Vcon,Vdes,Vpar,VV,WSSV,Xvas,Zbai,Zbis,ZIKV,Zrou,ZYMV
+                        '''
                         continue
 
                 elif not allele_prefix:
@@ -631,8 +651,8 @@ class FlyBase(PostgreSQLSource):
                         allele_curie
                     )
                 else:
-                    raise ValueError("Did not correct parse gene label {}"
-                                     .format(gene_label))
+                    raise ValueError(
+                        "Did not correct parse gene label {}".format(gene_label))
 
                 # Connect allele and gene with geno.addAffectedLocus()
                 if allele_prefix and gene_prefix:

--- a/dipper/sources/FlyBase.py
+++ b/dipper/sources/FlyBase.py
@@ -494,7 +494,9 @@ class FlyBase(PostgreSQLSource):
 
     def _process_gene_xref(self, limit):
         """
-        Make eq axioms between flybase gene ids and ncbi gene and hgnc
+        Make equivalentClass axioms between flybase gene ids
+            and NCBIGene
+            and HGNC noting these are not expected to be orthologs just bad renaming.
 
         Note that there are a lot of genes in flybase from other organisms
         we make the eq axioms so that they clique merge in our large graph
@@ -529,6 +531,7 @@ class FlyBase(PostgreSQLSource):
                     xref_prefix = 'NCBIGene'
                 elif xref_source == 'HGNC':
                     xref_prefix = 'HGNC'
+                    # gene_taxon = self.globaltt['Homo sapiens']
                 xref_curie = xref_prefix + ':' + xref_id
 
                 model.addEquivalentClass(

--- a/dipper/sources/GWASCatalog.py
+++ b/dipper/sources/GWASCatalog.py
@@ -494,12 +494,12 @@ class GWASCatalog(Source):
                     geno.addAffectedLocus(snp_id, 'ENSEMBL:' + geneid)
 
         # add the up and downstream genes if they are available
-        if upstream_gene_num != '':
+        if downstream_gene_num != '':
             downstream_gene_id = 'ENSEMBL:' + downstream_gene_num
             graph.addTriple(
                 snp_id, self.globaltt['is upstream of sequence of'], downstream_gene_id
             )
-        if downstream_gene_num != '':
+        if upstream_gene_num != '':
             upstream_gene_id = 'ENSEMBL:' + upstream_gene_num
             graph.addTriple(
                 snp_id, self.globaltt['is downstream of sequence of'], upstream_gene_id

--- a/dipper/sources/GWASCatalog.py
+++ b/dipper/sources/GWASCatalog.py
@@ -538,7 +538,7 @@ class GWASCatalog(Source):
                     graph, pubmed_curie, self.globaltt['journal article'])
                 ref.addRefToGraph()
 
-                if trait_curie is not None and trait_curie != '' and
+                if trait_curie is not None and trait_curie != '' and \
                         variant_id is not None and variant_id != '':
                     assoc = G2PAssoc(
                         graph, self.name, variant_id, trait_curie,

--- a/dipper/sources/GWASCatalog.py
+++ b/dipper/sources/GWASCatalog.py
@@ -538,20 +538,22 @@ class GWASCatalog(Source):
                     graph, pubmed_curie, self.globaltt['journal article'])
                 ref.addRefToGraph()
 
-                assoc = G2PAssoc(
-                    graph, self.name, variant_id, trait_curie,
-                    model.globaltt['contributes to condition'])
-                assoc.add_source(pubmed_curie)
+                if trait_curie is not None and trait_curie != '' and
+                        variant_id is not None and variant_id != '':
+                    assoc = G2PAssoc(
+                        graph, self.name, variant_id, trait_curie,
+                        model.globaltt['contributes to condition'])
+                    assoc.add_source(pubmed_curie)
 
-                assoc.add_evidence(
-                    self.globaltt['combinatorial evidence used in automatic assertion'])
+                    assoc.add_evidence(
+                        self.globaltt['combinatorial evidence used in automatic assertion'])
 
-                if description is not None:
-                    assoc.set_description(description)
+                    if description is not None:
+                        assoc.set_description(description)
 
-                # FIXME score should get added to provenance/study
-                # assoc.set_score(pvalue)
-                if trait_curie is not None and variant_id is not None:
+                    # FIXME score should get added to provenance/study
+                    # assoc.set_score(pvalue)
+
                     assoc.add_association_to_graph()
 
     @staticmethod

--- a/dipper/sources/GeneOntology.py
+++ b/dipper/sources/GeneOntology.py
@@ -364,11 +364,13 @@ class GeneOntology(Source):
                                 gene_id, self.globaltt['has gene product'], syn)
                         elif re.fullmatch(graph.curie_regexp, syn) is not None and\
                                 syn.split(':')[0] not in self.wont_prefix:
+                            syn = syn.strip()
                             LOG.warning(
                                 'possible curie "%s" as a literal synomym for %s',
                                 syn, gene_id)
-                            model.addSynonym(gene_id, syn)
-                        else:
+                            if syn != '':
+                                model.addSynonym(gene_id, syn)
+                        elif syn != '':
                             model.addSynonym(gene_id, syn)
 
                 # First taxon is for the gene, after the pipe are interacting taxa

--- a/dipper/sources/IMPC.py
+++ b/dipper/sources/IMPC.py
@@ -655,7 +655,7 @@ class IMPC(Source):
         # Add parameter/measure statement: study measures parameter
         parameter_label = "{0} ({1})".format(parameter_name, procedure_name)
 
-        logging.info("Adding Provenance for %s", project_fullname)
+        # logging.info("Adding Provenance for %s", project_fullname)
         model.addIndividualToGraph(parameter_curie, parameter_label)
         provenance_model.add_study_measure(
             study_bnode, parameter_curie, object_is_literal=False
@@ -755,8 +755,8 @@ class IMPC(Source):
                 fold_change_bnode, None, self.globaltt['effect size estimate']
             )
             measurements[fold_change_bnode] = effect_size
-
-        evidence_model.add_supporting_data(evidence_line_bnode, measurements)
+        if measurements != {}:
+            evidence_model.add_supporting_data(evidence_line_bnode, measurements)
 
         # Link evidence to provenance by connecting to study node
         provenance_model.add_study_to_measurements(study_bnode, measurements.keys())

--- a/dipper/sources/OMIA.py
+++ b/dipper/sources/OMIA.py
@@ -639,8 +639,12 @@ class OMIA(OMIMSource):
 
         if self.test_mode and omia_id not in self.test_ids['disease']:
             return
+        # LIDIA is hard to find/redolve (404s; suspect offline)
+        # consider changing to model.addSynonym((omia_id, lidaurl)
+        # b/c uri are not literals
+        model.addXref(omia_id, lidaurl)
 
-        model.addXref(omia_id, lidaurl, True)
+
 
     def _process_phene_gene_row(self, row):
         geno = Genotype(self.graph)

--- a/dipper/sources/Orphanet.py
+++ b/dipper/sources/Orphanet.py
@@ -173,6 +173,9 @@ class Orphanet(Source):
                             dbxref, None, class_category=blv.terms['Gene']
                         )
                         model.addEquivalentClass(gene_curie, dbxref)
+                        # note: when dbxref is a Genatlas family,
+                        # the curie is/was mistaken as a literal
+                        # due to the trailing '@' on the symbol
 
                 syn_list = gene.find('./SynonymList')
                 if int(syn_list.get('count')) > 0 and gene_curie is not None:

--- a/dipper/sources/WormBase.py
+++ b/dipper/sources/WormBase.py
@@ -322,7 +322,7 @@ class WormBase(Source):
 
                 gene_id = 'WormBase:'+gene_num
 
-                if concise_description != 'none available':
+                if concise_description not in ('none available', '', None):
                     model.addDefinition(gene_id, concise_description)
 
                 # remove the description if it's identical to the concise
@@ -334,10 +334,8 @@ class WormBase(Source):
                 }
                 for d in descs:
                     text = descs.get(d)
-                    if text == concise_description \
-                            or re.match(r'none', text) or text == '':
-                        pass  # don't use it
-                    else:
+                    if text != concise_description and \
+                            text[:4] != 'none' and text != '':
                         text = ' '.join((text, '['+d+']'))
                         descs[d] = text
                         model.addDescription(gene_id, text)
@@ -733,7 +731,7 @@ WBRNAi00008687|WBPaper00005654 WBRNAi00025197|WBPaper00006395 WBRNAi00045381|WBP
                     else:
                         model.addSynonym(fid, name)
 
-                if desc is not None:
+                if desc is not None and desc != '':
                     model.addDescription(fid, desc)
 
                 alias = attribute_dict.get('Alias')
@@ -763,7 +761,7 @@ WBRNAi00008687|WBPaper00005654 WBRNAi00025197|WBPaper00006395 WBRNAi00045381|WBP
 
                 feature.addFeatureToGraph(True, None, feature_is_class)
 
-                if note is not None:
+                if note is not None and note != '':
                     model.addDescription(fid, note)
 
                 if limit is not None and line_counter > limit:
@@ -904,7 +902,8 @@ I	TF_binding_site_region	TF_binding_site	3403	4072	.	+	.	Name=WBsf331847;tf_id=W
                 assoc.add_association_to_graph()
                 assoc_id = assoc.get_association_id()
                 # citation is not a pmid or WBref - get this some other way
-                model.addDescription(assoc_id, summary)
+                if summary is not None and summary != '':
+                    model.addDescription(assoc_id, summary)
 
                 if limit is not None and line_counter > limit:
                     break

--- a/dipper/sources/ZFIN.py
+++ b/dipper/sources/ZFIN.py
@@ -731,7 +731,8 @@ class ZFIN(Source):
 
             # since we re-create a label,
             # add the zfin fish label as the synonym
-            model.addSynonym(fish_id, fish['fish_label'])
+            if fish['fish_label'] != '':
+                model.addSynonym(fish_id, fish['fish_label'])
             self.id_label_map[fish_id] = fish_label
 
             if not self.test_mode and limit is not None and reader.line_num > limit:
@@ -841,8 +842,10 @@ class ZFIN(Source):
                 geno.addGenotype(genotype_curie, None)
 
                 # add the given name from ZFIN and uniquename as synonyms
-                model.addSynonym(genotype_curie, genotype_name)
-                model.addSynonym(genotype_curie, genotype_unique_name)
+                if genotype_name != '':
+                    model.addSynonym(genotype_curie, genotype_name)
+                if genotype_unique_name != '':
+                    model.addSynonym(genotype_curie, genotype_unique_name)
 
                 # store the alleles of the genotype,
                 # in order to use when processing fish
@@ -870,7 +873,8 @@ class ZFIN(Source):
 
                 # alleles in zfin are really sequence alterations in our system
                 geno.addSequenceAlteration(allele_curie, allele_name, allele_type_id)
-                model.addSynonym(allele_curie, allele_ab)
+                if allele_ab != '':
+                    model.addSynonym(allele_curie, allele_ab)
 
                 # here, we assemble the items into a genotype hash
                 # we need to do this because each row only holds one allele
@@ -1171,9 +1175,9 @@ class ZFIN(Source):
 
             # add monarch_genotype_name as synonym
             monarch_genotype_name = gvc_label + ' [' + background_label + ']'
-            model.addSynonym(gt, monarch_genotype_name)
-
-            self.id_label_map[gt] = monarch_genotype_name
+            if monarch_genotype_name != '':
+                model.addSynonym(gt, monarch_genotype_name)
+                self.id_label_map[gt] = monarch_genotype_name
 
             # Add the GVC to the genotype
             geno.addParts(gvc_id, gt, self.globaltt['has_variant_part'])
@@ -1627,10 +1631,8 @@ class ZFIN(Source):
                 model.addIndividualToGraph(
                     genomfeat_curie, genomic_feature_name, feature_so_id
                 )
-
-                model.addSynonym(
-                    genomfeat_curie, genomic_feature_abbreviation
-                )
+                if genomic_feature_abbreviation != '':
+                    model.addSynonym(genomfeat_curie, genomic_feature_abbreviation)
 
                 if construct_id is not None and construct_id != '':
                     construct_curie = ':'.join(('ZFIN', construct_id))
@@ -2400,8 +2402,11 @@ class ZFIN(Source):
                     # add the panel as a genome build
                     panel_curie = ':'.join(('ZFIN', pinfo['id']))
                     geno.addReferenceGenome(panel_curie, panel_label, taxon_id)
-                    model.addSynonym(panel_curie, panel_symbol)
-                    model.addDescription(panel_curie, pinfo['name'])
+
+                    if panel_symbol != '':
+                        model.addSynonym(panel_curie, panel_symbol)
+                    if pinfo['name'] != '':
+                        model.addDescription(panel_curie, pinfo['name'])
 
                     # add the mapping-panel chromosome
                     chr_inst_id = makeChromID(chromosome, panel_curie, 'MONARCH')

--- a/translationtable/GLOBAL_TERMS.yaml
+++ b/translationtable/GLOBAL_TERMS.yaml
@@ -175,7 +175,6 @@
 "organization": "foaf:organization",
 "page": "foaf:page",
 "person": "foaf:Person",
-# ??? PATO_0000470: GENO:0000876
 # "Genotype Partonomy Ontology": "GENO:!!!",
 "intrinsic_genotype": "GENO:0000000",
 "variant_locus": "GENO:0000002",

--- a/translationtable/generated/curiemap_prefix.txt
+++ b/translationtable/generated/curiemap_prefix.txt
@@ -85,6 +85,7 @@
 "KEGG-img"
 "KEGG-ko"
 "KEGG-path"
+"LIDA"
 "LPT"
 "MA"
 "MEDDRA"


### PR DESCRIPTION
A pass across sources to mitigate inappropriate object literals.
 
 - Model.py
RDF object curies with uncommon chars (such as '@') 
could be emitted as literals if not explicitly declared as non-literals. 
This P.R. expands the cases where we explicitly declare objects.
Add check for description not being empty
must be curie/URI.

 - Orphanet
code comments were left for unintuitive cases 
and a stray line of comment was dropped

 - Flybase
ftp url was assembled without a path separator (Dipper cache likely covers)
avoid empty species/taxon designations. (leads to taxon prefix as literal)
collect the scores of not-mapped "species" (which are most likely internal strain tags)

 - Gwascatalog
Correct the guards on asserting up & down stream genes from a snp
previously missed asserting some that exist 
and asserted some empty strings which show up as empty literals.
filter out empty `contributes to condition` objects

 - OMIA
Add the apparently defunct `LIDA` db curie to  our curie_map
so the dbxref is not expresses as a literal.  

 - Animalqtldb
remove appended comma on incoming ncbi gene id (cause curie to be a literal)

 - Wormbase
 had 23.4k empty descriptions (untested fix)

 - Model, Zfin Go, Eom
filter empty synonyms

 - IMPC, Evidence
filter empty 'has_value'   (12.5k of them)

 - Animalqtldb, Model
filter empty `rdfs:label` ; fixes Ensembl & Flybase as well