### PR TITLE
Disambiguate dcat:Distribution from dcat:distribution

### DIFF
--- a/dipper/models/Dataset.py
+++ b/dipper/models/Dataset.py
@@ -290,7 +290,7 @@ class Dataset:
         self.model.addType(self.distribution_level_turtle_curie,
                            self.globaltt['Dataset'])
         self.model.addType(self.distribution_level_turtle_curie,
-                           self.globaltt['distribution'])
+                           self.globaltt['Distribution'])
         self.graph.addTriple(self.distribution_level_turtle_curie,
                              self.globaltt['title'],
                              self.ingest_title +

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -100,7 +100,8 @@ class DatasetTestCase(unittest.TestCase):
         cls.iri_retrieved_on = URIRef(cls.base_pav + "retrievedOn")
         cls.iri_creator = URIRef(cls.base_dcterms + "creator")
         cls.iri_is_version_of = URIRef(cls.base_dcterms + "isVersionOf")
-        cls.iri_distribution = URIRef(cls.base_dcat + "Distribution")
+        cls.iri_distribution = URIRef(cls.base_dcat + "distribution")
+        cls.iri_Distribution = URIRef(cls.base_dcat + "Distribution")
         cls.iri_created_with = URIRef(cls.base_pav + "createdWith")
         cls.iri_format = URIRef(cls.base_dcterms + "format")
         cls.iri_download_url = URIRef(cls.base_dcterms + "downloadURL")
@@ -342,7 +343,7 @@ class DatasetTestCase(unittest.TestCase):
         triples = list(self.dataset.graph.triples(
             (self.distribution_level_IRI_ttl,
              self.iri_rdf_type,
-             self.iri_distribution)))
+             self.iri_Distribution)))
         self.assertTrue(len(triples) == 1,
                         "missing version level type distribution triple")
 

--- a/translationtable/GLOBAL_TERMS.yaml
+++ b/translationtable/GLOBAL_TERMS.yaml
@@ -58,7 +58,7 @@
 "Microcell hybrid": "CLO:0036939",
 "Chorionic villus-derived cell line": "CLO:0036940",
 # "Data Catalog Vocabulary": "dcat:!!!"
-"distribution": "dcat:Distribution",
+"distribution": "dcat:distribution",
 "Distribution": "dcat:Distribution",
 # "dublin core terms": "dcterms:!!!",
 "Date Created": "dcterms:created",

--- a/translationtable/GLOBAL_TERMS.yaml
+++ b/translationtable/GLOBAL_TERMS.yaml
@@ -59,6 +59,7 @@
 "Chorionic villus-derived cell line": "CLO:0036940",
 # "Data Catalog Vocabulary": "dcat:!!!"
 "distribution": "dcat:Distribution",
+"Distribution": "dcat:Distribution",
 # "dublin core terms": "dcterms:!!!",
 "Date Created": "dcterms:created",
 "description": "dcterms:description",


### PR DESCRIPTION
Currently the dataset descriptions created by `dipper` only have the class IRI for `dcat:Distribution` and not the property IRI of `dcat:distribution`.

This PR updates the `GLOBAL_TERMS.yaml` to include the property as part of the map and updates the code to use the property correctly.

Fun fact, I detected this using the `kgx` package while validating the results after running dipper-etl.py for ensembl. Here is an example of the error and dataset descriptor that isn't valid.

```
[ERROR][INVALID_EDGE_LABEL] https://archive.monarchinitiative.org/20200908/#ensembl-https://archive.monarchinitiative.org/20200908/rdf/ensembl.ttl - Edge label 'DistributionLevel' is not in snake_case form
```

```
@prefix biolink: <https://w3id.org/biolink/vocab/> .
@prefix dcat: <http://www.w3.org/ns/dcat#> .
@prefix dcterms: <http://purl.org/dc/terms/> .
@prefix dctypes: <http://purl.org/dc/dcmitype/> .
@prefix owl: <http://www.w3.org/2002/07/owl#> .
@prefix pav: <http://purl.org/pav/> .
@prefix schema: <http://schema.org/> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

<http://www.ensembl.org/biomart/martservice?> pav:retrievedOn "2020-09-08"^^xsd:date .

<https://archive.monarchinitiative.org/#ensembl> a dctypes:Dataset,
        owl:Ontology ;
    dcterms:Publisher <https://monarchinitiative.org/> ;
    dcterms:identifier "MonarchArchive:#ensembl" ;
    dcterms:source <http://uswest.ensembl.org> ;
    dcterms:title "ENSEMBL" ;
    schema:logo <https://github.com/monarch-initiative/monarch-ui/blob/master/public/img/sources/source-ensembl.png> ;
    owl:versionIRI <https://archive.monarchinitiative.org/20200908/#ensembl> .

<https://archive.monarchinitiative.org/20200908/#ensembl> a dctypes:Dataset ;
    dcterms:Publisher <https://monarchinitiative.org/> ;
    dcterms:created "2020-09-08"^^xsd:date ;
    dcterms:creator <https://monarchinitiative.org/> ;
    dcterms:isVersionOf <https://archive.monarchinitiative.org/#ensembl> ;
    dcterms:source <http://www.ensembl.org/biomart/martservice?> ;
    dcterms:title "ENSEMBL Monarch version 20200908" ;
    pav:version "2020-09-08"^^xsd:date ;
    dcat:Distribution <https://archive.monarchinitiative.org/20200908/rdf/ensembl.ttl> ;
    biolink:category biolink:DataSetVersion .

<https://archive.monarchinitiative.org/20200908/rdf/ensembl.ttl> a dctypes:Dataset,
        dcat:Distribution ;
    dcterms:Publisher <https://monarchinitiative.org/> ;
    dcterms:created "2020-09-08"^^xsd:date ;
    dcterms:creator <https://monarchinitiative.org/> ;
    dcterms:downloadURL <https://archive.monarchinitiative.org/20200908/rdf/ensembl.ttl> ;
    dcterms:format <https://www.w3.org/TR/turtle/> ;
    dcterms:license <https://project-open-data.cio.gov/unknown-license/> ;
    dcterms:title "ENSEMBL distribution ttl" ;
    pav:createdWith <https://github.com/monarch-initiative/dipper> ;
    pav:version "2020-09-08"^^xsd:date .
```