### PR TITLE
Digest bnode ids &  refactor 

### DIFF
--- a/dipper/models/GenomicFeature.py
+++ b/dipper/models/GenomicFeature.py
@@ -260,7 +260,6 @@ class Feature():
         reference = re.sub(r'\w+\:', '', reference, 1)
         if reference[0] == '_':
             # in this case the reference is a bnode curie as well
-            # ... this is a bad smell of over modleing
             reference = reference[1:]
         unique_words = reference
         if coordinate is not None:
@@ -271,7 +270,7 @@ class Feature():
             if tstring is not None:
                 unique_words = '-'.join((unique_words, tstring))
 
-        curie = '_:' + self.gfxutl.digest_id(unique_words)
+        curie = '_:' + self.gfxutl.digest_id(unique_words)  # bnode
 
         # attach the wordage via a label
         # I want to see more of this (TEC 201905)

--- a/dipper/models/Genotype.py
+++ b/dipper/models/Genotype.py
@@ -197,7 +197,7 @@ class Genotype():
         :param product_id:
         :param product_label:
         :param product_type:
-        :param sequence_category: biolink category CURIE for sequence_id [blv.terms.Gene].value
+        :param sequence_category: bl category CURIE for sequence_id [blv.terms.Gene].value
         :param product_category: biolink category CURIE for product_id
         :return:
 
@@ -485,6 +485,7 @@ class Genotype():
         """
 
         # akin to a variant locus
+        # is this some sort of pseudo bnode?
         if targeted_gene_id is None:
             targeted_gene_id = '_' + gene_id + '-' + reagent_id
             targeted_gene_id = targeted_gene_id.replace(":", "")
@@ -688,8 +689,9 @@ class Genotype():
             self, genotype_id, genotype_label, taxon_id, taxon_label):
 
         animal_id = '-'.join((taxon_id, 'with', genotype_id))
-        animal_id = re.sub(r':', '', animal_id)
-        animal_id = '_:' + animal_id
+        animal_id = animal_id.replace(':', '')
+        # bnode
+        animal_id = self.make_id(animal_id, '_')
 
         animal_label = ' '.join((genotype_label, taxon_label))
         self.model.addIndividualToGraph(animal_id, animal_label, taxon_id)

--- a/dipper/models/Model.py
+++ b/dipper/models/Model.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from dipper.graph.Graph import Graph
 from dipper.models.BiolinkVocabulary import BioLinkVocabulary as blv
 
@@ -195,12 +194,14 @@ class Model():
             property_value_category=None
     ):
         # make a blank node to hold the property restrictions
-        # scrub the colons, they will make the ttl parsers choke
-        bnode = '_:'+re.sub(
-            r':', '', property_id)+re.sub(r':', '', property_value)
+        uniq_str = '-'.join((property_id, property_value))
+        bnode = self.make_id(uniq_str, '_')
 
         self.graph.addTriple(
             bnode, self.globaltt['type'], self.globaltt['restriction']
+        )
+        self.graph.addTriple(
+            bnode, self.globaltt['label'], uniq_str
         )
         self.graph.addTriple(
             bnode,

--- a/dipper/models/Pathway.py
+++ b/dipper/models/Pathway.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from dipper.models.Model import Model
 from dipper.graph.Graph import Graph
 
@@ -41,8 +40,7 @@ class Pathway():
         if pathway_type is None:
             pathway_type = self.globaltt['cellular_process']
         self.model.addClassToGraph(
-            pathway_id, pathway_label, pathway_type, pathway_description
-        )
+            pathway_id, pathway_label, pathway_type, pathway_description)
         self.model.addSubClass(pathway_id, self.globaltt['pathway'])
 
     def addGeneToPathway(self, gene_id, pathway_id):
@@ -58,11 +56,13 @@ class Pathway():
         :param gene_id:
         :return:
         """
-
-        gene_product = '_:' + re.sub(r':', '', gene_id) + 'product'
+        # bnode
+        gene_product = self.make_id(gene_id.replace(':', '') + 'product', '_')
         self.model.addIndividualToGraph(
-            gene_product, None, self.globaltt['gene_product'],
-        )
+            gene_product, None, self.globaltt['gene_product'])
+        self.graph.addTriple(
+            gene_product, self.globaltt['label'], pathway_id)
+
         self.graph.addTriple(gene_id, self.globaltt['has gene product'], gene_product)
         self.addComponentToPathway(gene_product, pathway_id)
 

--- a/dipper/models/assoc/G2PAssoc.py
+++ b/dipper/models/assoc/G2PAssoc.py
@@ -1,5 +1,4 @@
 import logging
-import re
 
 from dipper.models.assoc.Association import Assoc
 
@@ -88,13 +87,16 @@ class G2PAssoc(Assoc):
         # is this kosher?
         Assoc.add_association_to_graph(self)
 
-        # make a blank stage
+        # make a blank stage bnode
         if self.start_stage_id or self.end_stage_id is not None:
-            stage_process_id = '-'.join((str(self.start_stage_id),
-                                         str(self.end_stage_id)))
-            stage_process_id = '_:'+re.sub(r':', '', stage_process_id)
+            stage_process_str = '-'.join((
+                str(self.start_stage_id), str(self.end_stage_id)))
+            stage_process_id = self.make_id(stage_process_str.replace(':', ''), '_')
             self.model.addIndividualToGraph(
                 stage_process_id, None, self.globaltt['developmental_process']
+            )
+            self.graph.addTriple(
+                stage_process_id, self.globaltt['label'], stage_process_str
             )
 
             self.graph.addTriple(

--- a/dipper/sources/AnimalQTLdb.py
+++ b/dipper/sources/AnimalQTLdb.py
@@ -544,9 +544,9 @@ class AnimalQTLdb(Source):
                         geno.addAffectedLocus(qtl_id, gene_id)
 
                         if dbsnp_id is not None:
-                            # add the rsid as a seq alt of the gene_id
-                            vl_id = '_:' + re.sub(
-                                r':', '', gene_id) + '-' + peak_mark.strip()
+                            # add the rsid as a seq alt of the gene_id as a bnode
+                            vl_id = self.make_id(re.sub(
+                                r':', '', gene_id) + '-' + peak_mark.strip(), '_')
                             geno.addSequenceAlterationToVariantLocus(dbsnp_id, vl_id)
                             geno.addAffectedLocus(vl_id, gene_id)
 

--- a/dipper/sources/ClinVar.py
+++ b/dipper/sources/ClinVar.py
@@ -810,8 +810,8 @@ def parse():
     # main loop over xml
     # taken in chunks composed of ClinVarSet stanzas
     with gzip.open(filename, 'rt') as clinvar_fh:
-        TREE = ET.iterparse(clinvar_fh)  # w/o specifing events it defaults to 'end'
-        for event, element in TREE:
+        tree = ET.iterparse(clinvar_fh)  # w/o specifing events it defaults to 'end'
+        for event, element in tree:
             if element.tag != 'ClinVarSet':
                 ReleaseSet = element
                 continue
@@ -931,7 +931,7 @@ def parse():
                 # 142532 MedGen
 
                 for RCV_Trait in RCV_TraitSet.findall('./Trait[@Type="Disease"]'):
-                    has_medgen_id = False
+                    # has_medgen_id = False
                     rcv_disease_db = None
                     rcv_disease_id = None
                     medgen_id = None
@@ -1130,7 +1130,6 @@ def parse():
                         rcv_disease_curie, rcvtriples,
                         subject_category=blv.terms['Association'],
                         object_category=blv.terms['Disease'])
-                        # <rcv_disease_curi><rdfs:label><rcv_disease_label>  .
                     # <rcv_disease_curi><rdfs:label><rcv_disease_label>  .
                     # medgen might not have a disease label
                     if condition.label is not None:

--- a/dipper/sources/Coriell.py
+++ b/dipper/sources/Coriell.py
@@ -1,3 +1,5 @@
+'''
+'''
 import logging
 import csv
 import re
@@ -151,8 +153,6 @@ class Coriell(Source):
             LOG.error("not configured with FTP user/password.")
             # raise error
 
-        return
-
     def fetch(self, is_dl_forced=False):
         """
         Here we connect to the coriell sftp server using private connection
@@ -229,8 +229,6 @@ class Coriell(Source):
                 self.dataset.set_ingest_source(remote_url)
                 self.dataset.set_ingest_source_file_version_date(remote_url, filedate)
 
-        return
-
     def parse(self, limit=None):
         if limit is not None:
             LOG.info("Only parsing first %s rows of each file", limit)
@@ -247,7 +245,6 @@ class Coriell(Source):
             self._process_data(src_key, limit)
 
         LOG.info("Finished parsing.")
-        return
 
     def _process_data(self, src_key, limit=None):
         """
@@ -304,8 +301,6 @@ class Coriell(Source):
 
         family = Family(graph)
         model = Model(graph)
-
-        line_counter = 1
         geno = Genotype(graph)
         diputil = DipperUtil()
         col = self.files[src_key]['columns']
@@ -313,21 +308,21 @@ class Coriell(Source):
         # x = row[col.index('x')].strip()
 
         with open(raw, 'r', encoding="iso-8859-1") as csvfile:
-            filereader = csv.reader(csvfile, delimiter=',', quotechar=r'"')
+            reader = csv.reader(csvfile, delimiter=',', quotechar=r'"')
             # we can keep a close watch on changing file formats
-            fileheader = next(filereader, None)
-            fileheader = [c.lower() for c in fileheader]
+            row = next(reader, None)
+            fileheader = [c.lower() for c in row]
             if col != fileheader:  # assert
                 LOG.error('Expected  %s to have columns: %s', raw, col)
                 LOG.error('But Found %s to have columns: %s', raw, fileheader)
                 raise AssertionError('Incomming data headers have changed.')
 
-            for row in filereader:
-                line_counter += 1
+            for row in reader:
+
                 if len(row) != len(col):
                     LOG.warning(
                         'Expected %i values but find %i in  row %i',
-                        len(col), len(row), line_counter)
+                        len(col), len(row), reader.line_num)
                     continue
 
                 # (catalog_id, description, omim_number, sample_type,
@@ -377,17 +372,16 @@ class Coriell(Source):
                 # examples of repeated patients are:
                 #   famid=1159, member=1; fam=152,member=1
 
-                # Make the patient ID
-
-                # make an anonymous patient
-                patient_id = '_:person'
+                # Make the patient ID an anonymous patient bnode
+                patient_id = self.make_id('anonymous_patient_' + catalog_id, '_')
                 fam_id = row[col.index('fam')].strip()
-                fammember = row[col.index('fammember')].strip()
-                if fam_id != '':
-                    patient_id = '-'.join((patient_id, fam_id, fammember))
-                else:
-                    # make an anonymous patient
-                    patient_id = '-'.join((patient_id, catalog_id))
+                # fammember = row[col.index('fammember')].strip()
+
+                # changing the person because family is present seems odd
+                # if fam_id != '':
+                #    patient_id = '-'.join((patient_id, fam_id, fammember))
+                #    patient_id = make_id(
+                #        '-'.join((patient_id,  fam_id, fammember)), '_')
 
                 # properties of the individual patients:  sex, family id,
                 # member/relproband, description descriptions are
@@ -408,7 +402,7 @@ class Coriell(Source):
                 else:
                     LOG.warning(
                         'Novel Affected status  %s at row: %i of %s',
-                        affected, line_counter, raw)
+                        affected, reader.line_num, raw)
                 patient_label = ' '.join((affected, gender, relprob))
                 if relprob == 'proband':
                     patient_label = ' '.join((
@@ -455,7 +449,7 @@ class Coriell(Source):
                     # this would give a BNode that is an instance of Age.
                     # but i don't know how to connect
                     # the age node to the cell line? we need to ask @mbrush
-                    # age_id = '_'+re.sub('\s+','_',age)
+                    # age_id = self.make_id(re.sub('\s+','_',age), '_')
                     # gu.addIndividualToGraph(
                     #   graph,age_id,age,self.globaltt['age'])
                     # gu.addTriple(
@@ -546,8 +540,8 @@ class Coriell(Source):
                 karyotype = diputil.remove_control_characters(karyotype)
                 karyotype_id = None
                 if karyotype.strip() != '':
-                    karyotype_id = '_:'+re.sub(
-                        'MONARCH:', '', self.make_id(karyotype))
+                    karyotype_id = self.make_id(  # bnode
+                        re.sub('MONARCH:', '', self.make_id(karyotype)), '_')
                     # add karyotype as karyotype_variation_complement
                     model.addIndividualToGraph(
                         karyotype_id, karyotype,
@@ -593,15 +587,18 @@ class Coriell(Source):
                         karyotype):
 
                     gvc_id = karyotype_id
-                    if variant_id != '':
-                        gvc_id = '_:' + variant_id.replace(';', '-') + '-' \
-                            + re.sub(r'\w*:', '', karyotype_id)
+                    if variant_id != '':  # bnode
+                        gvc_id = self.make_id(
+                            '-'.join((
+                                variant_id.replace(';', '-'),
+                                re.sub(r'\w*:', '', karyotype_id))), '_')
+
                     if mutation.strip() != '':
                         gvc_label = '; '.join((varl, karyotype))
                     else:
                         gvc_label = karyotype
-                elif variant_id.strip() != '':
-                    gvc_id = '_:' + variant_id.replace(';', '-')
+                elif variant_id.strip() != '':  # bnode
+                    gvc_id = self.make_id(variant_id.replace(';', '-'), '_')
                     gvc_label = varl
                 else:
                     # wildtype?
@@ -647,8 +644,8 @@ class Coriell(Source):
 
                     for omim in omim_map:
                         # gene_id = 'OMIM:' + omim  # TODO unused
-                        vslc_id = '_:' + '-'.join(
-                            [omim + '.' + a for a in omim_map.get(omim)])
+                        vslc_id = self.make_id(
+                            '-'.join([omim + '.' + a for a in omim_map.get(omim)]), '_')
                         vslc_label = varl
                         # we don't really know the zygosity of
                         # the alleles at all.
@@ -680,8 +677,8 @@ class Coriell(Source):
                     # let's just say that this person is wildtype
                     model.addType(patient_id, self.globaltt['wildtype'])
                 elif genotype_id is None:
-                    # make an anonymous genotype id (aka blank node)
-                    genotype_id = '_:geno' + catalog_id.strip()
+                    # make an anonymous genotype id (aka bnode)
+                    genotype_id = self.make_id('geno' + catalog_id, '_')
 
                 # add the gvc
                 if gvc_id is not None:
@@ -716,7 +713,7 @@ class Coriell(Source):
                     else:
                         genotype_label = gvc_label
                         # use the catalog id as the background
-                    genotype_label += ' ['+catalog_id.strip()+']'
+                    genotype_label += ' [' + catalog_id.strip() + ']'
 
                 if genotype_id is not None and gvc_id is not None:
                     # only add the genotype if it has some parts
@@ -784,9 +781,8 @@ class Coriell(Source):
                         )
 
                 if not self.test_mode and (
-                        limit is not None and line_counter > limit):
+                        limit is not None and reader.line_num > limit):
                     break
-        return
 
     def _process_collection(self, collection_id, label, page):
         """
@@ -816,8 +812,6 @@ class Coriell(Source):
                 repo_id, repo_label, self.globaltt['collection']
             )
             reference.addPage(repo_id, repo_page)
-
-        return
 
     @staticmethod
     def _get_affected_chromosomes_from_karyotype(karyotype):

--- a/dipper/sources/Decipher.py
+++ b/dipper/sources/Decipher.py
@@ -134,7 +134,7 @@ class Decipher(Source):
             graph = self.graph
 
         # in order for this to work, we need to map the HGNC id-symbol;
-        hgnc = HGNC(self.graph_type, self.are_bnodes_skolemized)
+        # hgnc = HGNC(self.graph_type, self.are_bnodes_skolemized)
         # hgnc_symbol_id_map = hgnc.get_symbol_id_map()  # Does Not Exists in hgnc
 
         myzip = ZipFile(
@@ -151,33 +151,40 @@ class Decipher(Source):
             # score_means_by_measure = {}
             # strain_scores_by_measure = {}   # TODO theseare unused
             for row in reader:
-                line_counter += 1
                 if re.match(r'#', row[0]):   # skip comments
                     continue
 
-                (gencode_gene_name, mode, category, consequence, disease, omim,
-                 ddg2p_id, pubmed_ids, hpo_codes) = row
+                (gencode_gene_name,
+                 mode,
+                 category,
+                 consequence,
+                 disease,
+                 omim,
+                 ddg2p_id,
+                 pubmed_ids,
+                 hpo_codes) = row
 
                 # hgnc_id = hgnc_symbol_id_map.get(gencode_gene_name.strip())
-                if hgnc_id is None:
+                # if hgnc_id is None:
+                if True:
                     LOG.error(
-                        "Couldn't map the gene symbol %s to HGNC.",
+                        "FIXME Couldn't map the gene symbol %s to HGNC.",
                         gencode_gene_name)
                     unmapped_gene_count += 1
                     continue
                 # add the gene
-                self.model.addClassToGraph(hgnc_id, gencode_gene_name)
+                # self.model.addClassToGraph(hgnc_id, gencode_gene_name)
 
                 # TODO make VSLC with the variation
                 #   to associate with the disorder
                 # TODO use the Inheritance and Mutation consequence
                 #   to classify the VSLCs
 
-                allele_id = self.make_allele_by_consequence(
-                    consequence, hgnc_id, gencode_gene_name)
+                # allele_id = self.make_allele_by_consequence(
+                #    consequence, hgnc_id, gencode_gene_name)
 
                 if omim.strip() != '':
-                    omim_id = 'OMIM:'+str(omim.strip())
+                    omim_id = 'OMIM:' + str(omim.strip())
                     # assume this is declared elsewhere in ontology
                     self.model.addClassToGraph(omim_id, None)
 
@@ -191,7 +198,7 @@ class Decipher(Source):
                     # elif category.strip() == 'Not DD gene':
                     #    # TODO negative annotation
                     #    continue
-                    assoc = G2PAssoc(graph, self.name, allele_id, omim_id)
+                    # assoc = G2PAssoc(graph, self.name, allele_id, omim_id)
                     # TODO 'rel' is assigned to but never used
 
                     for p in re.split(r';', pubmed_ids):
@@ -219,7 +226,7 @@ class Decipher(Source):
                 # are they about the gene?  the omim disease?  something else?
                 # So, we wont create associations until this is clarified
 
-                if not self.test_mode and limit is not None and line_counter > limit:
+                if not self.test_mode and limit is not None and reader.line_num > limit:
                     break
 
         myzip.close()
@@ -273,7 +280,7 @@ class Decipher(Source):
         # make the allele
         allele_id = ''.join((gene_id, type_id))
         allele_id = re.sub(r':', '', allele_id)
-        allele_id = '_:'+allele_id  # make this a BNode
+        allele_id = self.make_id(allele_id)  # make this a BNode
         allele_label = ' '.join((consequence, 'allele in', gene_symbol))
 
         self.model.addIndividualToGraph(allele_id, allele_label, type_id)

--- a/dipper/sources/IMPC.py
+++ b/dipper/sources/IMPC.py
@@ -232,18 +232,18 @@ class IMPC(Source):
                 # colony ids sometimes have <> in them, spaces,
                 # or other non-alphanumerics and break our system;
                 # replace these with underscores
-                colony_id = '_:' + re.sub(r'\W+', '_', colony_raw)
+                # bnode
+                colony_id = self.make_id(colony_raw.replace(' ', '_'), '_')
 
-                if not re.match(r'MGI', allele_accession_id):
-                    allele_accession_id = '_:IMPC-' + re.sub(
-                        r':', '', allele_accession_id)
+                if allele_accession_id[:4] != 'MGI:':
+                    # bnode
+                    allele_accession_id = self.make_id(
+                        'IMPC-' + allele_accession_id, '_')
 
                 if re.search(r'EUROCURATE', strain_accession_id):
-                    # the eurocurate links don't resolve at IMPC
-                    # TODO blank nodes do not maintain identifiers
-                    strain_accession_id = '_:' + strain_accession_id
-
-                elif not re.match(r'MGI', strain_accession_id):
+                    # the eurocurate links don't resolve at IMPC ... bnode
+                    strain_accession_id = self.make_id(strain_accession_id, '_')
+                elif strain_accession_id[:4] != 'MGI:':
                     LOG.info(
                         "Found a strange strain accession...%s", strain_accession_id)
                     strain_accession_id = 'IMPC:' + strain_accession_id
@@ -325,8 +325,9 @@ class IMPC(Source):
                 # (and it's relationship to the marker, etc.) later
                 # FIXME is it really necessary to create this vslc
                 # when we always know it's unknown zygosity?
-                vslc_colony = '_:' + re.sub(
-                    r':', '', allele_accession_id + self.globaltt['indeterminate'])
+                # bnode
+                vslc_colony = self.make_id(
+                    allele_accession_id + self.globaltt['indeterminate'], '_')
                 vslc_colony_label = allele_symbol + '/<?>'
                 # for ease of reading, we make the colony genotype variables.
                 # in the future, it might be desired to keep the vslcs
@@ -386,8 +387,9 @@ class IMPC(Source):
                 # Add the VSLC
                 vslc_id = '-'.join(
                     (marker_accession_id, allele_accession_id, zygosity))
-                vslc_id = re.sub(r':', '', vslc_id)
-                vslc_id = '_:' + vslc_id
+                vslc_id = vslc_id.replace(':', '')
+                # bnode
+                vslc_id = self.make_id(vslc_id, '_')
                 model.addIndividualToGraph(
                     vslc_id,
                     vslc_name,
@@ -623,18 +625,15 @@ class IMPC(Source):
 
         # Add provenance
         # A study is a blank node equal to its parts
-        study_bnode = self.make_id("{0}{1}{2}{3}{4}{5}{6}{7}"
-            .format(
-                phenotyping_center,
-                colony,
-                project_fullname,
-                pipeline_stable_id,
-                procedure_stable_id,
-                parameter_stable_id,
-                statistical_method,
-                resource_name
-            ), '_'
-        )
+        study_bnode = self.make_id("{0}{1}{2}{3}{4}{5}{6}{7}".format(
+            phenotyping_center,
+            colony,
+            project_fullname,
+            pipeline_stable_id,
+            procedure_stable_id,
+            parameter_stable_id,
+            statistical_method,
+            resource_name), '_')
 
         model.addIndividualToGraph(study_bnode, None, self.globaltt['study'])
 
@@ -643,7 +642,8 @@ class IMPC(Source):
 
         pipeline_curie = 'IMPC-pipe:' + pipeline_stable_id
         procedure_curie = 'IMPC-proc:' + procedure_stable_id
-        parameter_curie = 'IMPC-param:' + procedure_stable_id + '#' + parameter_stable_id
+        parameter_curie = 'IMPC-param:' + procedure_stable_id
+        parameter_curie += '#' + parameter_stable_id
 
         # Add study parts
 

--- a/dipper/sources/IMPC.py
+++ b/dipper/sources/IMPC.py
@@ -280,9 +280,10 @@ class IMPC(Source):
                         variant_locus_id, variant_locus_name, variant_locus_type, None)
                     geno.addAlleleOfGene(variant_locus_id, marker_accession_id)
 
-                    # TAG bnode
-                    sequence_alteration_id = '_:seqalt' + re.sub(
-                        r':', '', allele_accession_id)
+                    # Tag bnode
+                    sequence_alteration_id = self.make_id(
+                        'seqalt' + re.sub(r':', '', allele_accession_id), '_')
+
                     geno.addSequenceAlterationToVariantLocus(
                         sequence_alteration_id, variant_locus_id)
 
@@ -435,7 +436,8 @@ class IMPC(Source):
                         re.sub(r'\W+', '', colony_raw)))
                     if not re.match(r'^_', pheno_center_strain_id):
                         # Tag bnode
-                        pheno_center_strain_id = '_:' + pheno_center_strain_id
+                        pheno_center_strain_id = self.make_id(
+                            pheno_center_strain_id, '_')
 
                     geno.addGenotype(
                         pheno_center_strain_id,
@@ -631,8 +633,7 @@ class IMPC(Source):
                 parameter_stable_id,
                 statistical_method,
                 resource_name
-            ),
-            '_'
+            ), '_'
         )
 
         model.addIndividualToGraph(study_bnode, None, self.globaltt['study'])

--- a/dipper/sources/KEGG.py
+++ b/dipper/sources/KEGG.py
@@ -4,7 +4,7 @@ import re
 
 from dipper.sources.OMIMSource import OMIMSource
 from dipper.models.assoc.G2PAssoc import G2PAssoc
-from dipper.models.assoc.OrthologyAssoc import OrthologyAssoc
+# from dipper.models.assoc.OrthologyAssoc import OrthologyAssoc
 from dipper.models.Genotype import Genotype
 from dipper.models.Family import Family
 from dipper.models.Reference import Reference
@@ -184,13 +184,13 @@ class KEGG(OMIMSource):
                 if self.test_mode and pathway_id not in self.test_ids['pathway']:
                     continue
 
-                pathway_id = 'KEGG-'+pathway_id.strip()
+                pathway_id = 'KEGG-' + pathway_id.strip()
                 path.addPathway(pathway_id, pathway_name)
 
                 # we know that the pathway images from kegg map 1:1 here.
                 # so add those
                 image_filename = re.sub(r'KEGG-path:', '', pathway_id) + '.png'
-                image_url = 'http://www.genome.jp/kegg/pathway/map/'+image_filename
+                image_url = 'http://www.genome.jp/kegg/pathway/map/' + image_filename
                 model.addDepiction(pathway_id, image_url)
 
                 if not self.test_mode and limit is not None and reader.line_num > limit:
@@ -221,7 +221,7 @@ class KEGG(OMIMSource):
             for row in reader:
                 (disease_id, disease_name) = row
 
-                disease_id = 'KEGG-'+disease_id.strip()
+                disease_id = 'KEGG-' + disease_id.strip()
                 if disease_id not in self.label_hash:
                     self.label_hash[disease_id] = disease_name
 
@@ -274,7 +274,7 @@ class KEGG(OMIMSource):
             for row in reader:
                 (gene_id, gene_name) = row
 
-                gene_id = 'KEGG-'+gene_id.strip()
+                gene_id = 'KEGG-' + gene_id.strip()
 
                 # the gene listing has a bunch of labels
                 # that are delimited, as:
@@ -314,7 +314,7 @@ class KEGG(OMIMSource):
                     ko_part = gene_stuff[2]
                     ko_match = re.search(r'K\d+', ko_part)
                     if ko_match is not None and len(ko_match.groups()) == 1:
-                        ko = 'KEGG-ko:'+ko_match.group(1)
+                        ko = 'KEGG-ko:' + ko_match.group(1)
                         family.addMemberOf(gene_id, ko)
 
                 if not self.test_mode and limit is not None and reader.line_num > limit:
@@ -374,7 +374,7 @@ class KEGG(OMIMSource):
                         model.addSynonym(orthology_class_id, s.strip())
 
                     # add the last one as the description
-                    d = other_labels[len(other_labels)-1]
+                    d = other_labels[len(other_labels) - 1]
                     model.addDescription(orthology_class_id, d)
 
                     # add the enzyme commission number (EC:1.2.99.5)as an xref
@@ -805,8 +805,10 @@ class KEGG(OMIMSource):
         :return:
 
         """
-        alt_locus_id = '_:'+re.sub(
-            r':', '', gene_id) + '-' + re.sub(r':', '', disease_id) + 'VL'
+        # bnode
+        alt_locus_id = self.make_id(
+            '-'.join((gene_id.replace(':', ''), disease_id.replace(':', ''), 'VL')))
+
         alt_label = self.label_hash.get(gene_id)
         disease_label = self.label_hash.get(disease_id)
         if alt_label is not None and alt_label != '':

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -810,7 +810,7 @@ SELECT  r._relationship_key as rel_key,
 
                 if self.test_mode is True and \
                         int(allele_key) not in self.test_keys.get('allele'):
-                        continue
+                    continue
                 #  so are allele_key ints or not?  -TEC
                 allele_id = self.idhash['allele'].get(allele_key)
                 if allele_id is None:
@@ -2315,7 +2315,7 @@ SELECT  r._relationship_key as rel_key,
 
         """
         # these are just more blank node identifiers
-        iid = self.make_id('mgi' + prefix + 'key' + key, '_')
+        iid = Source.make_id('mgi' + prefix + 'key' + key, '_')
 
         return iid
 

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -1039,7 +1039,7 @@ SELECT  r._relationship_key as rel_key,
             if len(vslcs) > 1:
                 gvc_id = re.sub(r'_', '', ('-'.join(vslcs)))
                 gvc_id = re.sub(r':', '', gvc_id)
-                gvc_id = '_:' + gvc_id
+                gvc_id = self.make_id(gvc_id, '_')
                 vslc_labels = []
                 for v in vslcs:
                     vslc_labels.append(self.label_hash[v])
@@ -2314,8 +2314,8 @@ SELECT  r._relationship_key as rel_key,
         :return:
 
         """
-        # these are just blank nodes
-        iid = '_:mgi' + prefix + 'key' + key
+        # these are just more blank node identifiers
+        iid = self.make_id('mgi' + prefix + 'key' + key, '_')
 
         return iid
 

--- a/dipper/sources/MMRRC.py
+++ b/dipper/sources/MMRRC.py
@@ -330,7 +330,7 @@ class MMRRC(Source):
                 else:  # len(vars) == 0
                     # it's just anonymous variants in some gene
                     for gene in genes:
-                        vl_id = '_:' + re.sub(r':', '', gene) + '-VL'
+                        vl_id = self.make_id(re.sub(r':', '', gene) + '-VL', '_')
                         vl_symbol = self.id_label_hash[gene] + '<?>'
                         self.id_label_hash[vl_id] = vl_symbol
                         geno.addAllele(
@@ -346,7 +346,7 @@ class MMRRC(Source):
                     # for unknown zygosity
                     vslc_id = re.sub(r'^_', '', vl) + 'U'
                     vslc_id = re.sub(r':', '', vslc_id)
-                    vslc_id = '_:' + vslc_id
+                    vslc_id = self.make_id(vslc_id, '_')
                     vslc_label = self.id_label_hash[vl] + '/?'
                     self.id_label_hash[vslc_id] = vslc_label
                     vslc_list.append(vslc_id)
@@ -365,9 +365,9 @@ class MMRRC(Source):
                     )
                 if vslc_list:
                     if len(vslc_list) > 1:
-                        gvc_id = '-'.join(vslc_list)
+                        gvc_id = self.make_id(str(vslc_list), '_')
                         gvc_id = re.sub(r'_|:', '', gvc_id)
-                        gvc_id = '_:' + gvc_id
+                        gvc_id = self.make_id(gvc_id, '_')
                         gvc_label = '; '.join(self.id_label_hash[v] for v in vslc_list)
                         model.addIndividualToGraph(
                             gvc_id,
@@ -386,7 +386,7 @@ class MMRRC(Source):
                         r':', '', '-'.join((
                             self.globaltt['unspecified_genomic_background'], strain)))
                     genotype_id = '-'.join((gvc_id, bkgd_id))
-                    bkgd_id = '_:' + bkgd_id
+                    bkgd_id = self.make_id(bkgd_id, '_')
                     geno.addTaxon(mouse_taxon, bkgd_id)
                     geno.addGenomicBackground(
                         bkgd_id, 'unspecified (' + strain + ')',

--- a/dipper/sources/MMRRC.py
+++ b/dipper/sources/MMRRC.py
@@ -391,7 +391,8 @@ class MMRRC(Source):
                     geno.addGenomicBackground(
                         bkgd_id, 'unspecified (' + strain + ')',
                         self.globaltt['unspecified_genomic_background'],
-                        "A placeholder for the unspecified genetic background for " + strain)
+                        "A placeholder for the unspecified genetic background for " +
+                        strain)
                     geno.addGenomicBackgroundToGenotype(
                         bkgd_id, genotype_id,
                         self.globaltt['unspecified_genomic_background'])

--- a/dipper/sources/MPD.py
+++ b/dipper/sources/MPD.py
@@ -480,12 +480,14 @@ class MPD(Source):
         model = Model(graph)
         eco_id = self.globaltt['experimental phenotypic evidence']
         strain_label = self.idlabel_hash.get(strain_id)
-        # strain genotype
-        genotype_id = '_:' + '-'.join((re.sub(r':', '', strain_id), 'genotype'))
+        # strain genotype bnode
+        genotype_id = self.make_id(
+            '-'.join((re.sub(r':', '', strain_id), 'genotype')), '_')
         genotype_label = '[' + strain_label + ']'
 
-        sex_specific_genotype_id = '_:' + '-'.join(
-            (re.sub(r':', '', strain_id), sex, 'genotype'))
+        # bnode
+        sex_specific_genotype_id = self.make_id(
+            '-'.join((strain_id.replace(':', ''), sex, 'genotype')), '_')
         if strain_label is not None:
             sex_specific_genotype_label = strain_label + ' (' + sex + ')'
         else:

--- a/dipper/sources/OMIA.py
+++ b/dipper/sources/OMIA.py
@@ -666,7 +666,7 @@ class OMIA(OMIMSource):
 
         gene_label = self.label_hash[gene_id]
         # some variant of gene_id has phenotype d
-        var = '_:' + gene_id.split(':')[-1] + 'VL'
+        var = self.make_id(gene_id.split(':')[-1] + 'VL', '_')
         geno.addAllele(var, 'some variant of ' + gene_label)
         geno.addAlleleOfGene(var, gene_id)
         geno.addAffectedLocus(var, gene_id)

--- a/dipper/sources/Source.py
+++ b/dipper/sources/Source.py
@@ -155,7 +155,7 @@ class Source:
         )
 
         # see jenkins file   human, mouse, zebrafish, fly, worm        rat
-        self.COMMON_TAXON = ['9606','10090','7955','7227','6239']  # '10116'
+        self.COMMON_TAXON = ['9606', '10090', '7955', '7227', '6239']  # '10116'
 
     def fetch(self, is_dl_forced=False):
         """
@@ -456,12 +456,12 @@ class Source:
             try:
                 request = urllib.request.Request(remoteurl, headers=headers)
                 response = urllib.request.urlopen(request)
-            except urllib.error.HTTPError as httpErr:
+            except urllib.error.HTTPError as httperr:
                 # raise Exception(httpErr.read())
-                LOG.error('NETWORK issue %s\n\tFor: %s', httpErr.read(), remoteurl)
+                LOG.error('NETWORK issue %s\n\tFor: %s', httperr.read(), remoteurl)
                 return False  # allows re try (e.g. not found in Cache)
-            except urllib.error.URLError as urlErr:
-                LOG.error('URLError %s\n\tFor: %s', urlErr, remoteurl)
+            except urllib.error.URLError as urlerr:
+                LOG.error('URLError %s\n\tFor: %s', urlerr, remoteurl)
             result = response is not None
             if localfile is not None and result:
                 with open(localfile, 'wb') as binwrite:

--- a/dipper/sources/WormBase.py
+++ b/dipper/sources/WormBase.py
@@ -536,7 +536,7 @@ class WormBase(Source):
                             # @kshefchek - removing this blank node
                             # in favor of simpler modeling, treat variant
                             # like an allele
-                            # vl_id = '_:'+'-'.join((gene_num, allele_num))
+                            # vl_id = make_id('+'-'.join((gene_num, allele_num)), '_')
                             # geno.addSequenceAlterationToVariantLocus(
                             #    allele_id, vl_id)
                             # geno.addAlleleOfGene(vl_id, gene_id)

--- a/dipper/sources/ZFIN.py
+++ b/dipper/sources/ZFIN.py
@@ -680,8 +680,8 @@ class ZFIN(Source):
                     list_of_targeted_genes += [targeted_gene_id]
                     # end loop through each gene that is targeted
                 list_of_targeted_genes = sorted(list_of_targeted_genes)
-                extrinsic_id = '_:' + re.sub(
-                    r':?_?', '', '-'.join(list_of_targeted_genes))
+                extrinsic_id = self.make_id(
+                    r':?_?', '', '-'.join(list_of_targeted_genes)). '_')
                 extrinsic_label = '; '.join(
                     str(self.id_label_map.get(l))
                     for l in list_of_targeted_genes)
@@ -1067,7 +1067,7 @@ class ZFIN(Source):
 
                 # TODO also consider adding this to Genotype.py
                 vslc_id = '-'.join((gn, allele1_id, allele2_id))
-                vslc_id = '_:' + re.sub(r'(ZFIN)?:', '', vslc_id)
+                vslc_id = self.make_id(re.sub(r'(ZFIN)?:', '', vslc_id), '_')
 
                 vslc_label = geno.make_vslc_label(
                     gene_label, allele1_label, allele2_label)
@@ -1110,7 +1110,7 @@ class ZFIN(Source):
 
                 gvc_id = '-'.join(gvc_parts)
                 gvc_id = re.sub(r'(ZFIN)?:', '', gvc_id)
-                gvc_id = '_:' + re.sub(r'^_*', '', gvc_id)
+                gvc_id = self.make_id(re.sub(r'^_*', '', gvc_id), '_')
 
                 for vslc_id in gvc_parts:
                     # add the vslc to the gvc
@@ -1154,7 +1154,7 @@ class ZFIN(Source):
 
             else:
                 background_num = re.sub(r'ZFIN:', '', gt)
-                background_id = '_:bkgd-' + background_num
+                background_id = self.make_id('bkgd-' + background_num, '_')
                 background_label = 'unspecified background'
                 background_label_and_num = \
                     'unspecified background (' + background_num + ')'
@@ -1930,7 +1930,7 @@ class ZFIN(Source):
         transgene_part_id = '-'.join((
             construct_id, part_id, re.sub(r'\W+', '-', relationship)))
         transgene_part_id = re.sub(r'ZFIN:', '', transgene_part_id)
-        transgene_part_id = '_:' + transgene_part_id
+        transgene_part_id = self.make_id(transgene_part_id, '_')
 
         return transgene_part_id
 
@@ -2901,7 +2901,7 @@ class ZFIN(Source):
         """
 
         varloci = '-'.join((gene_id, allele_id))
-        varloci = '_:' + re.sub(r'(ZFIN)?:', '', varloci)
+        varloci = self.make_id(re.sub(r'(ZFIN)?:', '', varloci), '_')
 
         return varloci
 
@@ -3089,10 +3089,10 @@ class ZFIN(Source):
         targeted_gene_id = '-'.join((geneid, reagentid))
         # these are not zfin resolvable, so make BNodes
         targeted_gene_id = re.sub(r'(ZFIN)?:', '', targeted_gene_id)
-        targeted_gene_id = '_:' + targeted_gene_id
+        targeted_gene_id = self.make_id(targeted_gene_id, '_')
         return targeted_gene_id
 
-    # #### SOME OLD (COBLO?) CODE #####
+    # #### SOME OLD (COBOL?) CODE #####
 
 # # LINK THE MORPHOLINO TO THE GENES THAT IT AFFECTS
 # AG = SELF.VARIANT_LOCI_GENES.GET(MORPH_ID)

--- a/dipper/sources/ZFIN.py
+++ b/dipper/sources/ZFIN.py
@@ -680,11 +680,10 @@ class ZFIN(Source):
                     list_of_targeted_genes += [targeted_gene_id]
                     # end loop through each gene that is targeted
                 list_of_targeted_genes = sorted(list_of_targeted_genes)
-                extrinsic_id = self.make_id(
-                    r':?_?', '', '-'.join(list_of_targeted_genes)). '_')
-                extrinsic_label = '; '.join(
+                extrinsic_id = self.make_id('-'.join(list_of_targeted_genes), '_')
+                extrinsic_label = '; '.join([
                     str(self.id_label_map.get(l))
-                    for l in list_of_targeted_genes)
+                    for l in list_of_targeted_genes])
                 self.id_label_map[extrinsic_id] = extrinsic_label
 
                 # add the parts
@@ -1036,8 +1035,7 @@ class ZFIN(Source):
                         allele1_id, vloci1)
                     geno.addAlleleOfGene(vloci1, gene_curie)
                     model.addIndividualToGraph(
-                        vloci1, vloci1_label, self.globaltt['variant_locus']
-                    )
+                        vloci1, vloci1_label, self.globaltt['variant_locus'])
                     if allele2_id is not None and allele2_id not in ['WT', '0', 'UN']:
                         vloci2 = self._make_variant_locus_id(
                             gene_curie, allele2_id)
@@ -1930,7 +1928,7 @@ class ZFIN(Source):
         transgene_part_id = '-'.join((
             construct_id, part_id, re.sub(r'\W+', '-', relationship)))
         transgene_part_id = re.sub(r'ZFIN:', '', transgene_part_id)
-        transgene_part_id = self.make_id(transgene_part_id, '_')
+        transgene_part_id = Source.make_id(transgene_part_id, '_')
 
         return transgene_part_id
 
@@ -2289,7 +2287,7 @@ class ZFIN(Source):
                 # if subcond_id != '':
                 #   env_component_id = '-'.join((env_component_id, subcond_id))
                 # make them blank nodes
-                # env_component_id = '_:' + env_component_id
+                # env_component_id = self.make_id(env_component_id, '_')  # bnode
                 # env_condition = condition.strip()
                 # env_component_label = condition_group + '[' + condition + ']'
                 # if description != '':
@@ -2901,7 +2899,7 @@ class ZFIN(Source):
         """
 
         varloci = '-'.join((gene_id, allele_id))
-        varloci = self.make_id(re.sub(r'(ZFIN)?:', '', varloci), '_')
+        varloci = Source.make_id(re.sub(r'(ZFIN)?:', '', varloci), '_')
 
         return varloci
 
@@ -3089,7 +3087,7 @@ class ZFIN(Source):
         targeted_gene_id = '-'.join((geneid, reagentid))
         # these are not zfin resolvable, so make BNodes
         targeted_gene_id = re.sub(r'(ZFIN)?:', '', targeted_gene_id)
-        targeted_gene_id = self.make_id(targeted_gene_id, '_')
+        targeted_gene_id = Source.make_id(targeted_gene_id, '_')
         return targeted_gene_id
 
     # #### SOME OLD (COBOL?) CODE #####


### PR DESCRIPTION

 - try to have more bnode identifiers be predictable deterministic hashes
 - wormbase got a refactor for column headers
 - many misc refactos through out

embedding meaning in bnode identifiers as we have is a lost cause
hopefully no one relies on them.

We should be able to remove a bunch of processing intended to
keep cruft out of ids which never occur in a digest/hash hex-string. 
