### PR TITLE
Adendum to PR #982   (Digest bnode ids & refactor)

### DIFF
--- a/dipper/graph/RDFGraph.py
+++ b/dipper/graph/RDFGraph.py
@@ -41,8 +41,10 @@ class RDFGraph(DipperGraph, ConjunctiveGraph):
 
         # Can be removed when this is resolved
         # https://github.com/RDFLib/rdflib/issues/632
-        for pfx in ('OBO',):  # , 'ORPHA'):
-            self.bind(pfx, Namespace(self.curie_map[pfx]))
+		# 2020 oct. possibly fixed
+        # for pfx in ('OBO',):  # , 'ORPHA'):
+        #    self.bind(pfx, Namespace(self.curie_map[pfx]))
+
 
     def _make_category_triple(
             self, subject, category, predicate=blv.terms['category']

--- a/dipper/models/Genotype.py
+++ b/dipper/models/Genotype.py
@@ -3,6 +3,7 @@ import re
 from dipper.models.Model import Model
 from dipper.models.Family import Family
 from dipper.graph.Graph import Graph
+from dipper.utils.GraphUtils import GraphUtils
 from dipper.models.GenomicFeature import makeChromID, makeChromLabel
 from dipper.models.BiolinkVocabulary import BioLinkVocabulary as blv
 
@@ -30,7 +31,7 @@ class Genotype():
         self.globaltt = self.graph.globaltt
         self.globaltcid = self.graph.globaltcid
         self.curie_map = self.graph.curie_map
-        return
+        self.gut = GraphUtils(self.curie_map)
 
     def addGenotype(
             self, genotype_id, genotype_label,
@@ -197,7 +198,7 @@ class Genotype():
         :param product_id:
         :param product_label:
         :param product_type:
-        :param sequence_category: bl category CURIE for sequence_id [blv.terms.Gene].value
+        :param sequence_category: bl category CURIE for seq_id [blv.terms.Gene].value
         :param product_category: biolink category CURIE for product_id
         :return:
 
@@ -691,7 +692,7 @@ class Genotype():
         animal_id = '-'.join((taxon_id, 'with', genotype_id))
         animal_id = animal_id.replace(':', '')
         # bnode
-        animal_id = self.make_id(animal_id, '_')
+        animal_id = ':'.join(('_', self.gut.digest_id(animal_id)))
 
         animal_label = ' '.join((genotype_label, taxon_label))
         self.model.addIndividualToGraph(animal_id, animal_label, taxon_id)

--- a/dipper/models/Model.py
+++ b/dipper/models/Model.py
@@ -1,5 +1,6 @@
 import logging
 from dipper.graph.Graph import Graph
+from dipper.utils.GraphUtils import GraphUtils
 from dipper.models.BiolinkVocabulary import BioLinkVocabulary as blv
 
 LOG = logging.getLogger(__name__)
@@ -21,6 +22,8 @@ class Model():
 
         else:
             raise ValueError("{} is not a graph".format(graph))
+
+        self.gut = GraphUtils(None)  # self.curie_map
 
     def addTriple(
             self,
@@ -193,9 +196,9 @@ class Model():
             property_id_category=None,
             property_value_category=None
     ):
-        # make a blank node to hold the property restrictions
+        # make a bnode to hold the property restrictions
         uniq_str = '-'.join((property_id, property_value))
-        bnode = self.make_id(uniq_str, '_')
+        bnode = ':'.join(('_', self.gut.digest_id(uniq_str)))
 
         self.graph.addTriple(
             bnode, self.globaltt['type'], self.globaltt['restriction']

--- a/dipper/models/assoc/G2PAssoc.py
+++ b/dipper/models/assoc/G2PAssoc.py
@@ -1,6 +1,7 @@
 import logging
 
 from dipper.models.assoc.Association import Assoc
+from dipper.utils.GraphUtils import GraphUtils
 
 __author__ = 'nlw'
 
@@ -49,6 +50,7 @@ class G2PAssoc(Assoc):
 
         self.subject_category = entity_category
         self.object_category = phenotype_category
+        self.gut = GraphUtils(None)
 
         return
 
@@ -87,11 +89,12 @@ class G2PAssoc(Assoc):
         # is this kosher?
         Assoc.add_association_to_graph(self)
 
-        # make a blank stage bnode
+        # make a blank stage
         if self.start_stage_id or self.end_stage_id is not None:
             stage_process_str = '-'.join((
                 str(self.start_stage_id), str(self.end_stage_id)))
-            stage_process_id = self.make_id(stage_process_str.replace(':', ''), '_')
+            stage_process_id = ':'.join(  # bnode
+                ('_', self.gut.digest_id(stage_process_str)))
             self.model.addIndividualToGraph(
                 stage_process_id, None, self.globaltt['developmental_process']
             )

--- a/dipper/sources/MGI.py
+++ b/dipper/sources/MGI.py
@@ -990,16 +990,21 @@ SELECT  r._relationship_key as rel_key,
                             self.globaltt['hemizygous insertion-linked'],
                             self.globaltt['hemizygous-x'],
                             self.globaltt['hemizygous-y'],
-                            self.globaltt['hemizygous']]:
+                            self.globaltt['hemizygous'],
+                    ]:
                         vslc_label += '0'
                     elif zygosity_id == self.globaltt['heterozygous']:
                         vslc_label += '+'
                     elif zygosity_id == self.globaltt['indeterminate']:
                         vslc_label += '?'
+                    elif zygosity_id == self.globaltt['heteroplasmic']:
+                        vslc_label += '?'  # todo is there anything else to add here?
+                    elif zygosity_id == self.globaltt['homoplasmic']:
+                        vslc_label += '?'  # todo is there anything else to add here?
                     elif zygosity_id == self.globaltt['homozygous']:
                         # we shouldn't get here, but for testing this is handy
                         vslc_label += allele1
-                    else:  # heteroplasmic,  homoplasmic,  FIXME add these if possible
+                    else:
                         LOG.info(
                             "A different kind of zygosity found is: %s",
                             self.globaltcid[zygosity_id])
@@ -2301,8 +2306,7 @@ SELECT  r._relationship_key as rel_key,
                 if not self.test_mode and limit is not None and reader.line_num > limit:
                     break
 
-    @staticmethod
-    def _make_internal_identifier(prefix, key):
+    def _make_internal_identifier(self, prefix, key):
         """
         This is a special MGI-to-MONARCH-ism.
         MGI tables have unique keys that we use here, but don't want to
@@ -2315,7 +2319,7 @@ SELECT  r._relationship_key as rel_key,
 
         """
         # these are just more blank node identifiers
-        iid = Source.make_id('mgi' + prefix + 'key' + key, '_')
+        iid = self.make_id('mgi' + prefix + 'key' + key, '_')
 
         return iid
 


### PR DESCRIPTION
bnode ids digested within the model classes needed an alternative 
to the digest function in Source.make_id()'  unless we change all the signatures to pass it.

zfin & mgi  run locally , expect others will as well