### PR TITLE
Go: fix list gaf list parsing

### DIFF
--- a/dipper/curie_map.yaml
+++ b/dipper/curie_map.yaml
@@ -17,7 +17,7 @@
 'xml': 'http://www.w3.org/XML/1998/namespace'                       # Extensible Markup Language
 'xsd': 'http://www.w3.org/2001/XMLSchema#'                          # XML Schema Definition
 'owl': 'http://www.w3.org/2002/07/owl#'                             # Web Ontology Language
-'skos': 'https://www.w3.org/TR/skos-reference/#'                    # Simple Knowledge Organization System
+'skos': 'http://www.w3.org/2004/02/skos/core#'                      # Simple Knowledge Organization System
 # 'Annotation': 'http://www.w3.org/ns/oa#Annotation'                # Web annotation
 'schema': 'http://schema.org/'                                      # Schema.org "provides schemas for structured data on the Internet"
 

--- a/dipper/sources/GeneOntology.py
+++ b/dipper/sources/GeneOntology.py
@@ -56,7 +56,7 @@ class GeneOntology(Source):
         'GO_ID',
         'DB:Reference',
         'Evidence Code',
-        'With (or) From',
+        'With (or) From',  # list possible w/pipe(or)  w/comma(and) +both
         'Aspect',
         'DB_Object_Name',
         'DB_Object_Synonym',
@@ -440,7 +440,7 @@ class GeneOntology(Source):
                 # in version 2.0, multiple values are separated by pipes
                 # where the pipe has been used to mean 'AND'
                 if eco_symbol == 'IMP' and with_or_from != '':
-                    withitems = with_or_from.split('|')
+                    withitems = re.split(r'[|,]', with_or_from)  # OR + AND
                     phenotypeid = go_id + 'PHENOTYPE'
                     # create phenotype associations
                     for itm in withitems:

--- a/translationtable/animalqtldb.yaml
+++ b/translationtable/animalqtldb.yaml
@@ -1,7 +1,5 @@
 ---
 # animalqtldb.yaml
-# note ncbi requests the curie_prefix:local_id of NCBI:txid1234
-# we could move closer the that  i.e.  NCBItxid:1234
 "chicken": "Gallus gallus"  # NCBITaxon:9031
 "pig": "Sus scrofa"         # NCBITaxon:9823
 "horse": "Equus caballus"   # NCBITaxon:9796
@@ -13,8 +11,8 @@
 # This is not yet confirmed, thus is not utilized.
 
 #    "chicken": "Wageningen-chicken"    # PMID:10645958
-#    "cattle": "USDA-MARC"          	# PMID:9074927
-#    "pig": "USDA-MARC"         		# PMID:8743988
+#    "cattle": "USDA-MARC"              # PMID:9074927
+#    "pig": "USDA-MARC"                 # PMID:8743988
 #    # -- this is an assumption
 #    "sheep": "Wageningen-sheep"        # PMID:11435411
 #    "horse": "Swinburne-Penedo"        # PMID:16314071 PMID:16093715


### PR DESCRIPTION
column 8 may use both pipe and comma as list delimiter.
Aparently, only pipe had been encountered thus  far.

update a skos base-uri
