### PR TITLE
add new variant type 'haplotype, single variant'

### DIFF
--- a/translationtable/clinvar.yaml
+++ b/translationtable/clinvar.yaml
@@ -120,6 +120,7 @@
 "protein only": "protein_altering_variant"
 "CompoundHeterozygote": "compound heterozygous"
 "Haplotype": "haplotype"
+"Haplotype, single variant": "haplotype"
 "Phase unknown": "haplotype"
 "Distinct chromosomes": "mosaic"
 # ############################################################


### PR DESCRIPTION
clinvar has a new variant type called 'haplotype, single variant', translating it to our global term for 'haplotype'