### PR TITLE
IMPC

### DIFF
--- a/dipper/curie_map.yaml
+++ b/dipper/curie_map.yaml
@@ -124,7 +124,7 @@
 'MPD-assay': 'https://phenome.jax.org/db/qp?rtn=views/catlines&keymeas='  # Mouse Phenome Database assay
 'PMID': 'http://www.ncbi.nlm.nih.gov/pubmed/'                       # PubMed Identifier
 'PMCID': 'http://www.ncbi.nlm.nih.gov/pmc/'                         # PubMed Central Identifier
-'NCBIBSgene': 'http://www.ncbi.nlm.nih.gov/bookshelf/br.fcgi?book=gene&part=' 		  # NCBI BookShelf Gene book citation
+'NCBIBSgene': 'http://www.ncbi.nlm.nih.gov/bookshelf/br.fcgi?book=gene&part='         # NCBI BookShelf Gene book citation
 'AspGD_REF': 'http://www.aspergillusgenome.org/cgi-bin/reference/reference.pl?dbid='  # Aspergillus DB citation
 
 'AQTLPub': 'https://www.animalgenome.org/cgi-bin/QTLdb/BT/qabstract?PUBMED_ID='  # Animal Quantitative Trait Locus Publication
@@ -154,7 +154,7 @@
 # organisms and genome builds
 #                                                                       # National Center for Biotechnology Information
 'NCBIAssembly': 'https://www.ncbi.nlm.nih.gov/assembly?term='           #   Assembly  e.g. GRCh38
-'NCBIGenome': 'https://www.ncbi.nlm.nih.gov/genome/'                    #   Genome	  e.g. 51  (for human)
+'NCBIGenome': 'https://www.ncbi.nlm.nih.gov/genome/'                    #   Genome    e.g. 51  (for human)
 'NCBITaxon': 'http://purl.obolibrary.org/obo/NCBITaxon_'                #   Taxon     e.g. 9606
 'OMIA-breed': 'https://monarchinitiative.org/model/OMIA-breed:'         # Local IRI for Online Inheritance In Animal breeds
 'UCSC': 'ftp://hgdownload.cse.ucsc.edu/goldenPath/'                     # University of California, Santa Cruz golden path

--- a/dipper/curie_map.yaml
+++ b/dipper/curie_map.yaml
@@ -107,11 +107,11 @@
 'VIVO': 'http://vivoweb.org/ontology/core#'                         # ontology for representing scholarship
 'vfb': 'http://virtualflybrain.org/reports/'                        # Drosophila neuroanatomy
 
-
 # phenotype
 'EOM': 'https://elementsofmorphology.nih.gov/index.cgi?tid='         # Elements of Morphology phentoypes
 'EOM_IMG': 'https://elementsofmorphology.nih.gov/images/terms/'
-# publication/reference sources
+
+# publication/citation/reference sources
 'DOI': 'http://dx.doi.org/'                                         # Digital Object identifier
 'GeneReviews': 'http://www.ncbi.nlm.nih.gov/books/'                 # NCBI gene and diseases
 # more bogus IRIs
@@ -124,6 +124,7 @@
 'MPD-assay': 'https://phenome.jax.org/db/qp?rtn=views/catlines&keymeas='  # Mouse Phenome Database assay
 'PMID': 'http://www.ncbi.nlm.nih.gov/pubmed/'                       # PubMed Identifier
 'PMCID': 'http://www.ncbi.nlm.nih.gov/pmc/'                         # PubMed Central Identifier
+'NCBIBSgene': 'http://www.ncbi.nlm.nih.gov/bookshelf/br.fcgi?book=gene&part=' 		  # NCBI BookShelf Gene book citation
 'AspGD_REF': 'http://www.aspergillusgenome.org/cgi-bin/reference/reference.pl?dbid='  # Aspergillus DB citation
 
 'AQTLPub': 'https://www.animalgenome.org/cgi-bin/QTLdb/BT/qabstract?PUBMED_ID='  # Animal Quantitative Trait Locus Publication

--- a/dipper/sources/IMPC.py
+++ b/dipper/sources/IMPC.py
@@ -1,6 +1,5 @@
 import csv
-# import gzip  # just till they stop taring single files again? ...
-import tarfile
+import gzip
 import re
 import logging
 import os
@@ -18,7 +17,8 @@ IMPC = 'ftp://ftp.ebi.ac.uk/pub/databases/impc'
 # Sometimes latest disappears
 # IMPCDL = IMPC + 'latest/csv'  # seems gone for good now
 # hope they restore a stable path to the current release ...fingers crossed
-IMPC_V12 = IMPC + '/all-data-releases/release-12.0/results'
+# IMPCREL = IMPC + '/all-data-releases/release-12.0/results'
+IMPCREL = IMPC + '/all-data-releases/latest/results'
 GITHUBRAW = 'https://raw.githubusercontent.com/'
 
 
@@ -69,8 +69,9 @@ class IMPC(Source):
         'g2p_assertions': {
             # 'file': 'ALL_genotype_phenotype.csv.gz',  # pre v12.0
             # 'url': IMPCDL + '/ALL_genotype_phenotype.csv.gz',
-            'file': 'genotype-phenotype-assertions-ALL.csv.tgz',
-            'url': IMPC_V12 + '/genotype-phenotype-assertions-ALL.csv.tgz',
+            # 'file': 'genotype-phenotype-assertions-ALL.csv.tgz',
+            'file': 'genotype-phenotype-assertions-ALL.csv.gz',
+            'url': IMPCREL + '/genotype-phenotype-assertions-ALL.csv.tgz',
             'columns': [  # head -1 | tr ',' '\n' | sed "s|\(.*\)|'\1',|g"
                 'marker_accession_id',
                 'marker_symbol',
@@ -104,7 +105,7 @@ class IMPC(Source):
         },
         'checksum': {
             'file': 'genotype-phenotype-assertions-ALL.csv.tgz.md5',
-            'url': IMPC_V12 + '/genotype-phenotype-assertions-ALL.csv.tgz.md5',
+            'url': IMPCREL + '/genotype-phenotype-assertions-ALL.csv.tgz.md5',
         },
         'evidence': {  # manually isolated from their mysql data dump circa 2020 May
             'file': 'impc_evidence_stable_key.tsv',
@@ -187,15 +188,15 @@ class IMPC(Source):
         model.addClassToGraph(taxon_id, None)
         col = self.files[src_key]['columns']
 
+        # various (recuring) macinations as they evolve
         # with open(raw, 'r', encoding="utf8") as csvfile:
-        # with gzip.open(raw, 'rt') as csvfile:
+        # tarball = tarfile.open(raw, 'r:gz')
+        # tarball.extractall(path=self.rawdir)
+        # tarball.close()
+        # halfbaked = self.rawdir + '/genotype-phenotype-assertions-ALL.csv'
+        # with open(halfbaked, 'rt') as csvfile:
 
-        tarball = tarfile.open(raw, 'r:gz')
-        tarball.extractall(path=self.rawdir)
-        tarball.close()
-
-        halfbaked = self.rawdir + '/genotype-phenotype-assertions-ALL.csv'
-        with open(halfbaked, 'rt') as csvfile:
+        with gzip.open(raw, 'rt') as csvfile:
             reader = csv.reader(csvfile, delimiter=',', quotechar='\"')
             row = next(reader)  # presumed header
             if not self.check_fileheader(col, row):

--- a/translationtable/impc.yaml
+++ b/translationtable/impc.yaml
@@ -76,3 +76,4 @@
 "Linear Model Using Generalized Least Squares framework, GLS, not including Weight": "generalized least squares estimation"
 "Linear Model Using Generalized Least Squares framework, GLS, including Weight": "generalized least squares estimation"
 "Reference Range Plus Test framework; quantile = 0.95 (Tails probability = 0.025)": "statistical model"
+"Binomial distribution probability": "statistical model"


### PR DESCRIPTION
revert / adapt to a few instabilities

# IMPC
 - They brought back the "/latest/"  dir as a link to the latest release so it need not be hardcoded
-  They stopped pointlessly tar-ing a single file into an archive before gzipping it 
-  They decided to not provide .md5 files instead of .md5 files dependent on replicating their entire file system structure.

- the latest data file had a new statistical method for the translation table.

# Curie map: 
 - added a mapping for the NCBI BookShelf which  use downstream 
 - better prefix ideas welcome

# Clinvar subset extract script
 - update to accept the ClinVarVariant:  IDs which did not exist when it was first written.