### PR TITLE
Switch to SSH for private repo pull

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,8 +55,7 @@ pipeline {
             steps {
                 dir('./config') {
                     git(
-                        url: 'https://github.com/monarch-initiative/configs.git',
-                        credentialsId: 'c36e48af-8e33-4977-be25-0555ebb4275a',
+                        url: 'git@github.com:monarch-initiative/configs.git',
                         branch: 'master'
                     )
                     sh '''


### PR DESCRIPTION
See https://issues.jenkins.io/browse/JENKINS-66381

As of August 13 our username and password in the jenkins credentials store are no longer working.  Switching to SSH seems to resolve it.